### PR TITLE
Make lager_transform work with boss_compiler's line offset

### DIFF
--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -200,6 +200,7 @@ transform_statement(Stmt) when is_list(Stmt) ->
 transform_statement(Stmt) ->
     Stmt.
 
+make_varname(Prefix, {Line, _}) -> make_varname(Prefix, Line);
 make_varname(Prefix, Line) ->
     list_to_atom(Prefix ++ atom_to_list(get(module)) ++ integer_to_list(Line)).
 


### PR DESCRIPTION
Makes lager work for ChicagoBoss' compiler as well.