### PR TITLE
Install file backend if not already installed in trace/3

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -178,6 +178,9 @@ trace_console(Filter, Level) ->
 trace(Backend, Filter) ->
     trace(Backend, Filter, debug).
 
+trace({lager_file_backend, File}, Filter, Level) ->
+    trace_file(File, Filter, Level);
+
 trace(Backend, Filter, Level) ->
     Trace0 = {Filter, Level, Backend},
     case lager_util:validate_trace(Trace0) of


### PR DESCRIPTION
trace_file/3 already does this. So, call it from trace/3 in case of file
backend.

Fixes #158