### PR TITLE
Fix specification of backend config in log rotation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ use internal rotation, use the 'size', 'date' and 'count' values in the file
 backend's config:
 
 ```erlang
-[{name, "error.log"}, {level, error}, {size, 10485760}, {date, "$D0"}, {count, 5}]
+[{file, "error.log"}, {level, error}, {size, 10485760}, {date, "$D0"}, {count, 5}]
 ```
 
 This tells lager to log error and above messages to "error.log" and to


### PR DESCRIPTION
The example in "Internal log rotation" includes the tuple
{name, "error.log"}

This apparently should be

{file, "error.log"}

as seen in other config examples in README.md.