### PR TITLE
Add optional log_root environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ your app.config):
 
 ```erlang
 {lager, [
+  {log_root, "/var/log/hello"},
   {handlers, [
     {lager_console_backend, info},
     {lager_file_backend, [{file, "error.log"}, {level, error}]},
@@ -84,6 +85,8 @@ your app.config):
   ]}
 ]}.
 ```
+
+```log_root``` variable is optional, by default file paths are relative to CWD.
 
 The available configuration options for each backend are listed in their
 module's documentation.

--- a/src/lager_crash_log.erl
+++ b/src/lager_crash_log.erl
@@ -66,7 +66,8 @@ start(Filename, MaxBytes, Size, Date, Count) ->
             Date, Count], []).
 
 %% @private
-init([Filename, MaxBytes, Size, Date, Count]) ->
+init([RelFilename, MaxBytes, Size, Date, Count]) ->
+    Filename = lager_util:expand_path(RelFilename),
     case lager_util:open_logfile(Filename, false) of
         {ok, {FD, Inode, _}} ->
             schedule_rotation(Date),

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -102,8 +102,9 @@ init(LogFileConfig) when is_list(LogFileConfig) ->
             {error, {fatal, bad_config}};
         Config ->
             %% probabably a better way to do this, but whatever
-            [Name, Level, Date, Size, Count, SyncInterval, SyncSize, SyncOn, CheckInterval, Formatter, FormatterConfig] =
+            [RelName, Level, Date, Size, Count, SyncInterval, SyncSize, SyncOn, CheckInterval, Formatter, FormatterConfig] =
               [proplists:get_value(Key, Config) || Key <- [file, level, date, size, count, sync_interval, sync_size, sync_on, check_interval, formatter, formatter_config]],
+            Name = lager_util:expand_path(RelName),
             schedule_rotation(Name, Date),
             State0 = #state{name=Name, level=Level, size=Size, date=Date, count=Count, formatter=Formatter,
                 formatter_config=FormatterConfig, sync_on=SyncOn, sync_interval=SyncInterval, sync_size=SyncSize,

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -22,7 +22,7 @@
         open_logfile/2, ensure_logfile/4, rotate_logfile/2, format_time/0, format_time/1,
         localtime_ms/0, localtime_ms/1, maybe_utc/1, parse_rotation_date_spec/1,
         calculate_next_rotation/1, validate_trace/1, check_traces/4, is_loggable/3,
-        trace_filter/1, trace_filter/2]).
+        trace_filter/1, trace_filter/2, expand_path/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -467,6 +467,15 @@ i2l(I)              -> integer_to_list(I).
 i3l(I) when I < 100 -> [$0 | i2l(I)];
 i3l(I)              -> integer_to_list(I).
 
+%% When log_root option is provided, get the real path to a file
+expand_path(RelPath) ->
+    case application:get_env(lager, log_root) of
+        {ok, LogRoot} when is_list(LogRoot) -> % Join relative path
+            filename:join(LogRoot, RelPath);
+        undefined -> % No log_root given, keep relative path
+            RelPath
+    end.
+
 -ifdef(TEST).
 
 parse_test() ->
@@ -705,6 +714,23 @@ mask_to_levels_test() ->
     ?assertEqual([debug, info], mask_to_levels(2#11000000)),
     ?assertEqual([debug, info, emergency], mask_to_levels(2#11000001)),
     ?assertEqual([debug, notice, error], mask_to_levels(?DEBUG bor ?NOTICE bor ?ERROR)),
+    ok.
+
+expand_path_test() ->
+    OldRootVal = application:get_env(lager, log_root),
+
+    ok = application:unset_env(lager, log_root),
+    ?assertEqual("/foo/bar", expand_path("/foo/bar")),
+    ?assertEqual("foo/bar", expand_path("foo/bar")),
+
+    ok = application:set_env(lager, log_root, "log/dir"),
+    ?assertEqual("/foo/bar", expand_path("/foo/bar")), % Absolute path should not be changed
+    ?assertEqual("log/dir/foo/bar", expand_path("foo/bar")),
+
+    case OldRootVal of
+        undefined -> application:unset_env(lager, log_root);
+        {ok, Root} -> application:set_env(lager, log_root, Root)
+    end,
     ok.
 
 -endif.


### PR DESCRIPTION
When using multiple log files, usually all filenames have common directory.
When application has several environments (e.g. development and production) the log directory may differ.
When adding a new log file, the developer has to be careful to edit log path according to the environment.

Moving log directory to the separate environment variable allows to apply logging changes by using just ```diff``` and ```patch``` utilities. Also application config becomes shorter.