### PR TITLE
make trace and stop_trace take the same arguments

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -27,7 +27,7 @@
         log/3, log/4,
         md/0, md/1,
         trace/2, trace/3, trace_file/2, trace_file/3, trace_file/4, trace_console/1, trace_console/2,
-        clear_all_traces/0, stop_trace/1, status/0, 
+        clear_all_traces/0, stop_trace/3, status/0, 
         get_loglevel/1, set_loglevel/2, set_loglevel/3, get_loglevels/0,
         update_loglevel_config/0, posix_error/1,
         safe_format/3, safe_format_chop/3, dispatch_log/5, dispatch_log/9, 
@@ -195,18 +195,27 @@ trace(Backend, Filter, Level) ->
             Error
     end.
 
-stop_trace({_Filter, _Level, Target} = Trace) ->
+stop_trace(Backend, Filter, Level) ->
+    Trace0 = {Filter, Level, Backend},
+    case lager_util:validate_trace(Trace0) of
+        {ok, Trace} ->
+            stop_trace(Trace);
+        Error ->
+            Error
+    end.
+
+stop_trace({Backend, _Filter, _Level} = Trace) ->
     {Level, Traces} = lager_config:get(loglevel),
     NewTraces =  lists:delete(Trace, Traces),
     _ = lager_util:trace_filter([ element(1, T) || T <- NewTraces ]),
     %MinLevel = minimum_loglevel(get_loglevels() ++ get_trace_levels(NewTraces)),
     lager_config:set(loglevel, {Level, NewTraces}),
-    case get_loglevel(Target) of
+    case get_loglevel(Backend) of
         none ->
             %% check no other traces point here
-            case lists:keyfind(Target, 3, NewTraces) of
+            case lists:keyfind(Backend, 3, NewTraces) of
                 false ->
-                    gen_event:delete_handler(lager_event, Target, []);
+                    gen_event:delete_handler(lager_event, Backend, []);
                 _ ->
                     ok
             end;


### PR DESCRIPTION
starting a filtered trace is easy enough, one would expect the stop_trace to receive the same arguments.
for example, starting a trace:
lager:trace(lager_console_backend, [{module, users_serv}, {function, is_client_update_available}], debug).

to stop the trace, one must issue the following (non-intuitive) command:
lager:stop_trace({{all,[{module,'=',users_serv},{function,'=',is_client_update_available}]},{mask,255},lager_console_backend}).

with this PR the stop_trace now becomes:
lager:stop_trace(lager_console_backend, [{module, users_serv}, {function, is_client_update_available}], debug).