### PR TITLE
Flow control messages to lager_file_backend by adding high water mark

### DIFF
--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -100,3 +100,15 @@
     end)).
 -endif.
 
+-record(lager_shaper, {
+		  %% how many messages per second we try to deliver
+		  hwm = undefined :: 'undefined' | pos_integer(),
+		  %% how many messages we've received this second
+		  mps = 0 :: non_neg_integer(),
+		  %% the current second
+		  lasttime = os:timestamp() :: erlang:timestamp(),
+		  %% count of dropped messages this second
+		  dropped = 0 :: non_neg_integer()
+		 }).
+
+-type lager_shaper() :: #lager_shaper{}.

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -33,16 +33,7 @@
 
 -export([format_reason/1]).
 
--record(state, {
-        %% how many messages per second we try to deliver
-        hwm = undefined :: 'undefined' | pos_integer(),
-        %% how many messages we've received this second
-        mps = 0 :: non_neg_integer(),
-        %% the current second
-        lasttime = os:timestamp() :: erlang:timestamp(),
-        %% count of dropped messages this second
-        dropped = 0 :: non_neg_integer()
-    }).
+-record(state, { shaper :: lager_shaper() }).
 
 -define(LOGMSG(Level, Pid, Msg),
     case ?SHOULD_LOG(Level) of
@@ -75,19 +66,28 @@ set_high_water(N) ->
 
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark]) ->
-    {ok, #state{hwm=HighWaterMark}}.
+	Shaper = #lager_shaper{hwm=HighWaterMark},
+    {ok, #state{shaper=Shaper}}.
 
-handle_call({set_high_water, N}, State) ->
-    {ok, ok, State#state{hwm = N}};
+handle_call({set_high_water, N}, #state{shaper=Shaper} = State) ->
+	NewShaper = Shaper#lager_shaper{hwm=N},
+    {ok, ok, State#state{shaper = NewShaper}};
 handle_call(_Request, State) ->
     {ok, unknown_call, State}.
 
-handle_event(Event, State) ->
-    case check_hwm(State) of
-        {true, NewState} ->
-            log_event(Event, NewState);
-        {false, NewState} ->
-            {ok, NewState}
+handle_event(Event, #state{shaper=Shaper} = State) ->
+    case lager_util:check_hwm(Shaper) of
+        {true, Drop, #lager_shaper{hwm=Hwm} = NewShaper} ->
+			case Drop > 0 of
+                true ->
+					?LOGFMT(warning, self(), "lager_error_logger_h dropped ~p messages in the last second that exceeded the limit of ~p messages/sec",
+							[Drop, Hwm]);
+                false ->
+                    ok
+            end,
+            log_event(Event, State#state{shaper=NewShaper});
+        {false, _, NewShaper} ->
+            {ok, State#state{shaper=NewShaper}}
     end.
 
 handle_info(_Info, State) ->
@@ -100,50 +100,6 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 %% internal functions
-
-check_hwm(State = #state{hwm = undefined}) ->
-    {true, State};
-check_hwm(State = #state{mps = Mps, hwm = Hwm}) when Mps < Hwm ->
-    %% haven't hit high water mark yet, just log it
-    {true, State#state{mps=Mps+1}};
-check_hwm(State = #state{hwm = Hwm, lasttime = Last, dropped = Drop}) ->
-    %% are we still in the same second?
-    {M, S, _} = Now = os:timestamp(),
-    case Last of
-        {M, S, _} ->
-            %% still in same second, but have exceeded the high water mark
-            NewDrops = discard_messages(Now, 0),
-            {false, State#state{dropped=Drop+NewDrops}};
-        _ ->
-            %% different second, reset all counters and allow it
-            case Drop > 0 of
-                true ->
-                    ?LOGFMT(warning, self(), "lager_error_logger_h dropped ~p messages in the last second that exceeded the limit of ~p messages/sec",
-                        [Drop, Hwm]);
-                false ->
-                    ok
-            end,
-            {true, State#state{dropped = 0, mps=1, lasttime = Now}}
-    end.
-
-discard_messages(Second, Count) ->
-    {M, S, _} = os:timestamp(),
-    case Second of
-        {M, S, _} ->
-            receive
-                %% we only discard gen_event notifications, because
-                %% otherwise we might discard gen_event internal
-                %% messages, such as trapped EXITs
-                {notify, _Event} ->
-                    discard_messages(Second, Count+1);
-                {_From, _Tag, {sync_notify, _Event}} ->
-                    discard_messages(Second, Count+1)
-            after 0 ->
-                    Count
-            end;
-        _ ->
-            Count
-    end.
 
 log_event(Event, State) ->
     case Event of

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -29,7 +29,7 @@
         trace/2, trace/3, trace_file/2, trace_file/3, trace_file/4, trace_console/1, trace_console/2,
         clear_all_traces/0, stop_trace/1, status/0, 
         get_loglevel/1, set_loglevel/2, set_loglevel/3, get_loglevels/0,
-        update_loglevel_config/0, posix_error/1,
+        update_loglevel_config/0, posix_error/1, set_loghwm/2, set_loghwm/3,		
         safe_format/3, safe_format_chop/3, dispatch_log/5, dispatch_log/9, 
         do_log/9, pr/2]).
 
@@ -319,6 +319,14 @@ posix_error(Error) ->
 get_loglevels() ->
     [gen_event:call(lager_event, Handler, get_loglevel, infinity) ||
         Handler <- gen_event:which_handlers(lager_event)].
+
+%% @doc Set the loghwm for a particular backend.
+set_loghwm(Handler, Hwm) when is_integer(Hwm) ->
+    gen_event:call(lager_event, Handler, {set_loghwm, Hwm}, infinity).
+
+%% @doc Set the loghwm (log high water mark) for file backends with multiple identifiers
+set_loghwm(Handler, Ident, Hwm) when is_integer(Hwm) ->
+    gen_event:call(lager_event, {Handler, Ident}, {set_loghwm, Hwm}, infinity).
 
 %% @private
 add_trace_to_loglevel_config(Trace) ->

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -413,3 +413,4 @@ is_record_known(Record, Module) ->
                     end
             end
     end.
+

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -132,6 +132,15 @@ handle_call({set_loglevel, Level}, #state{name=Ident} = State) ->
     end;
 handle_call(get_loglevel, #state{level=Level} = State) ->
     {ok, Level, State};
+handle_call({set_loghwm, Hwm}, #state{shaper=Shaper, name=Name} = State) ->
+	case validate_logfile_proplist([{file, Name}, {high_water_mark, Hwm}]) of
+        false ->
+            {ok, {error, bad_log_hwm}, State};
+        _ ->
+			NewShaper = Shaper#lager_shaper{hwm=Hwm},
+			?INT_LOG(notice, "Changed loghwm of ~s to ~p", [Name, Hwm]),
+			{ok, {last_loghwm, Shaper#lager_shaper.hwm}, State#state{shaper=NewShaper}}
+	end;
 handle_call(_Request, State) ->
     {ok, ok, State}.
 

--- a/src/lager_util.erl
+++ b/src/lager_util.erl
@@ -496,8 +496,6 @@ discard_messages(Second, Count) ->
                 %% otherwise we might discard gen_event internal
                 %% messages, such as trapped EXITs
                 {notify, _Event} ->
-                    discard_messages(Second, Count+1);
-                {_From, _Tag, {sync_notify, _Event}} ->
                     discard_messages(Second, Count+1)
             after 0 ->
                     Count


### PR DESCRIPTION
Services using lager have to face high velocity of incoming messages, which would overflow the file backend. The situation is desperate when something abnormal events happen, and especially we're using cloud hosts.

The config error_logger_hwm only effects error_logger redirected but the raw file backend,  IIRC. So I add a similar configuration high_water_mark.

To be friendly for the PR, I've split it to three parts: 
1. Refactor the error_logger_hwm control codes, make it public to all modules by moving to lager_util;
2. add high_water_mark configuration to lager_file_backend;
3. add set_loghwm method to change high water mark on the fly.

Thanks in advance for your review.