### PR TITLE
add application stop/start suppression for ct logs

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -226,8 +226,13 @@ log_event(Event, State) ->
             Details = lists:sort(D),
             case Details of
                 [{application, App}, {exited, Reason}, {type, _Type}] ->
-                    ?LOGFMT(info, Pid, "Application ~w exited with reason: ~s",
-                        [App, format_reason(Reason)]);
+                    case application:get_env(lager, suppress_application_start_stop) of
+                        {ok, true} when Reason == stopped ->
+                            ok;
+                        _ ->
+                            ?LOGFMT(info, Pid, "Application ~w exited with reason: ~s",
+                                    [App, format_reason(Reason)])
+                    end;
                 _ ->
                     ?LOGMSG(info, Pid, print_silly_list(D))
             end;
@@ -237,8 +242,13 @@ log_event(Event, State) ->
             Details = lists:sort(D),
             case Details of
                 [{application, App}, {started_at, Node}] ->
-                    ?LOGFMT(info, P, "Application ~w started on node ~w",
-                        [App, Node]);
+                    case application:get_env(lager, suppress_application_start_stop) of
+                        {ok, true} ->
+                            ok;
+                        _ ->
+                            ?LOGFMT(info, P, "Application ~w started on node ~w",
+                                    [App, Node])
+                    end;
                 [{started, Started}, {supervisor, Name}] ->
                     MFA = format_mfa(get_value(mfargs, Started)),
                     Pid = get_value(pid, Started),

--- a/src/lager_common_test_backend.erl
+++ b/src/lager_common_test_backend.erl
@@ -40,10 +40,15 @@ bounce() ->
 
 bounce(Level) ->
     _ = application:stop(lager),
-    application:set_env(lager, handlers, [
-        {lager_common_test_backend, [Level, false]}
-    ]),
+    application:set_env(lager, suppress_application_start_stop, true),
+    application:set_env(lager, handlers,
+                        [
+                         {lager_common_test_backend, [Level, false]}
+                        ]),
     ok = lager:start(),
+    %% we care more about getting all of our messages here than being
+    %% careful with the amount of memory that we're using.
+    error_logger_lager_h:set_high_water(100000),
     ok.
 
 -spec(init(integer()|atom()|[term()]) -> {ok, #state{}} | {error, atom()}).


### PR DESCRIPTION
in common_test, starting and stopping applications can make your logs
very noisy.  the patch allows these messages to be suppressed on the
happy path, and raises the high water mark during ct tests so that
messages aren't dropped.