### PR TITLE
Strict config

### DIFF
--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -113,7 +113,7 @@ start(_StartType, _StartArgs) ->
                 end
         end,
 
-    _ = lager_util:trace_filter(none), 
+    _ = lager_util:trace_filter(none),
 
     {ok, Pid, SavedHandlers}.
 
@@ -153,7 +153,7 @@ add_configured_traces() ->
 
 maybe_make_handler_id(Mod, Config) ->
     %% Allow the backend to generate a gen_event handler id, if it wants to.
-    %% We don't use erlang:function_exported here because that requires the module 
+    %% We don't use erlang:function_exported here because that requires the module
     %% already be loaded, which is unlikely at this phase of startup. Using code:load
     %% caused undesireable side-effects with generating code-coverage reports.
     try Mod:config_to_id(Config) of

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -72,8 +72,10 @@ start(_StartType, _StartArgs) ->
     end,
 
     %% handlers failing to start are handled in the handler_watcher
-    _ = [supervisor:start_child(lager_handler_watcher_sup, [lager_event, Module, Config]) ||
-        {Module, Config} <- expand_handlers(Handlers)],
+    ok = lists:foreach(fun({Module, Config}) ->
+                           supervisor:start_child(lager_handler_watcher_sup, [lager_event, Module, Config])
+           end,
+                  expand_handlers(Handlers)),
 
     ok = add_configured_traces(),
 


### PR DESCRIPTION
This patch makes it so that handler config entries with the wrong number of values (i.e., forms other than the two expected members "module" and "config") are rejected at startup, rather than being silently ignored (since list comprehensions just drop any failed pattern matches).

Here is an example of a bad handler that would previously have been silently rejected:

      {lager_logstash_backend,
        {level, info},
        {output, {udp, "localhost", 5000}},
        {format, json},
        {json_encoder, jiffy}
      }

Here is what was actually meant:

      {lager_logstash_backend, [
        {level, info},
        {output, {udp, "localhost", 5000}},
        {format, json},
        {json_encoder, jiffy}
      ]}

(Note how it's a two-element tuple, where the second member is an association list, whereas the first example is a copy-pasting error.)