### PR TITLE
Provide means to compress printed record output

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -31,7 +31,7 @@
         get_loglevel/1, set_loglevel/2, set_loglevel/3, get_loglevels/0,
         update_loglevel_config/0, posix_error/1,
         safe_format/3, safe_format_chop/3, dispatch_log/5, dispatch_log/9, 
-        do_log/9, pr/2]).
+        do_log/9, pr/2, pr/3]).
 
 -type log_level() :: debug | info | notice | warning | error | critical | alert | emergency.
 -type log_level_number() :: 0..7.
@@ -368,34 +368,41 @@ safe_format_chop(Fmt, Args, Limit) ->
     safe_format(Fmt, Args, Limit, [{chomp, true}]).
 
 %% @doc Print a record lager found during parse transform
-pr(Record, Module) when is_tuple(Record), is_atom(element(1, Record)) ->
+pr(Record, Module) ->
+    pr(Record, Module, []).
+
+%% @doc Print a record lager found during parse transform
+pr(Record, Module, Options) when is_tuple(Record), is_atom(element(1, Record)), is_list(Options) ->
     try 
         case is_record_known(Record, Module) of
             false ->
                 Record;
             {RecordName, RecordFields} ->
                 {'$lager_record', RecordName, 
-                    zip(RecordFields, tl(tuple_to_list(Record)), Module, [])}
+                    zip(RecordFields, tl(tuple_to_list(Record)), Module, Options, [])}
         end
     catch
         error:undef ->
             Record
     end;
-pr(Record, _) ->
+pr(Record, _, _) ->
     Record.
 
-zip([FieldName|RecordFields], [FieldValue|Record], Module, ToReturn) ->
+zip([FieldName|RecordFields], [FieldValue|Record], Module, Options, ToReturn) ->
+    Compress = lists:member(compress, Options),
     case   is_tuple(FieldValue) andalso
            tuple_size(FieldValue) > 0 andalso
            is_atom(element(1, FieldValue)) andalso
            is_record_known(FieldValue, Module) of
+        false when Compress andalso FieldValue =:= undefined ->
+            zip(RecordFields, Record, Module, Options, ToReturn);
         false ->
-            zip(RecordFields, Record, Module, [{FieldName, FieldValue}|ToReturn]);
+            zip(RecordFields, Record, Module, Options, [{FieldName, FieldValue}|ToReturn]);
         _Else ->
-            F = {FieldName, pr(FieldValue, Module)},
-            zip(RecordFields, Record, Module, [F|ToReturn])
+            F = {FieldName, pr(FieldValue, Module, Options)},
+            zip(RecordFields, Record, Module, Options, [F|ToReturn])
     end;
-zip([], [], _Module, ToReturn) ->
+zip([], [], _Module, _Compress, ToReturn) ->
     lists:reverse(ToReturn).
 
 is_record_known(Record, Module) -> 

--- a/test/compress_pr_record_test.erl
+++ b/test/compress_pr_record_test.erl
@@ -1,0 +1,16 @@
+-module(compress_pr_record_test).
+
+-compile([{parse_transform, lager_transform}]).
+
+-record(a, {field1, field2, foo, bar, baz, zyu, zix}).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+nested_record_test() ->
+    A = #a{field1 = "Notice me senpai"},
+    Pr_A = lager:pr(A, ?MODULE),
+    Pr_A_Comp = lager:pr(A, ?MODULE, [compress]),
+    ?assertMatch({'$lager_record', a, [{field1, "Notice me senpai"}, {field2, undefined} | _]}, Pr_A),
+    ?assertEqual({'$lager_record', a, [{field1, "Notice me senpai"}]}, Pr_A_Comp).


### PR DESCRIPTION
Sometimes there are a LOT of records going through logging backends
which contain notable number of empty (i.e. undefined) fields. This
humble patch solemnly introduces new function `lager:pr/3` designed to
help cope with such kind of issues, providing a one and only option `compress`
which, when turned on, effectively eliminates any empty fields in records.