### PR TITLE
trace_file don't work, if env "log_root" is set.

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -708,6 +708,20 @@ filesystem_test_() ->
                         ?assertMatch([_, _, "[error]", _, "Test message\n"], re:split(Bin3, " ", [{return, list}, {parts, 5}]))
                 end
             },
+            {"tracing to a dedicated file should work even if root_log is set",
+                fun() ->
+                        {ok, P} = file:get_cwd(),
+                        file:delete(P ++ "/test_root_log/foo.log"),
+                        application:set_env(lager, log_root, P++"/test_root_log"),
+                        {ok, _} = lager:trace_file("foo.log", [{module, ?MODULE}]),
+                        lager:error("Test message"),
+                        %% not elegible for trace
+                        lager:log(error, self(), "Test message"),
+                        {ok, Bin3} = file:read_file(P++"/test_root_log/foo.log"),
+                        application:unset_env(lager, log_root),
+                        ?assertMatch([_, _, "[error]", _, "Test message\n"], re:split(Bin3, " ", [{return, list}, {parts, 5}]))
+                end
+            },
             {"tracing with options should work",
                 fun() ->
                         file:delete("foo.log"),


### PR DESCRIPTION
This is a little bugfix for trace_file funktion.