### PR TITLE
fix: when `log_root` set, `traces` will failed.

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -150,12 +150,13 @@ trace_file(File, Filter, Options) when is_list(Options) ->
     trace_file(File, Filter, debug, Options).
 
 trace_file(File, Filter, Level, Options) ->
-    Trace0 = {Filter, Level, {lager_file_backend, File}},
+    Id = lager_file_backend:get_log_name(File),
+    Trace0 = {Filter, Level, {lager_file_backend, Id}},
     case lager_util:validate_trace(Trace0) of
         {ok, Trace} ->
             Handlers = gen_event:which_handlers(lager_event),
             %% check if this file backend is already installed
-            Res = case lists:member({lager_file_backend, File}, Handlers) of
+            Res = case lists:member({lager_file_backend, Id}, Handlers) of
                false ->
                      %% install the handler
                     LogFileConfig = lists:keystore(level, 1, lists:keystore(file, 1, Options, {file, File}), {level, none}),

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -43,7 +43,7 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2,
         code_change/3]).
 
--export([config_to_id/1]).
+-export([config_to_id/1, get_log_name/1]).
 
 -define(DEFAULT_LOG_LEVEL, info).
 -define(DEFAULT_ROTATION_SIZE, 10485760). %% 10mb
@@ -180,6 +180,10 @@ config_to_id(Config) ->
         File ->
             {?MODULE, File}
     end.
+
+%% @private get log name by file name for later matches
+get_log_name(File) ->
+    lager_util:expand_path(File).
 
 
 write(#state{name=Name, fd=FD, inode=Inode, flap=Flap, size=RotSize,


### PR DESCRIPTION
when use traces, and set log_root as following, the traces will be failed, because the Name of log_filebackend not match : 

app.config
```
{lager, [
	  {log_root, "logs"},
	  {handlers, [
		      {lager_file_backend, [{file, "router_error.log"}, {level, error}]},
		      {lager_file_backend, [{file, "router_info.log"}, {level, info}]}
		     ]},
	  {traces, [
		    {{lager_file_backend, "user_online.log"}, [{module, rcp_client}, {function, help}], info}
		   ]}
]}.
```