### PR TITLE
Add support for group leader strategies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [debug_info, warn_untyped_record]}.
 {erl_first_files, ["src/lager_util.erl"]}.
 {deps, [
-        {goldrush, "0\.1\.6",
-            {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.6"}}}
+        {goldrush, "0\.1\.7",
+            {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.7"}}}
        ]}.
 
 {xref_checks, []}.


### PR DESCRIPTION
   The default strategy is 'handle', for backwards compatibility,
and is set to that if otherwise undefined.  Other strategies
include 'mirror' and 'ignore'.
   Before when the error_logger was removed when lager starts up,
some functionality was chopped off, such as forwarding io to the
caller's group leader, this is supported with the strategy 'ignore'
and is similar to how the io system in erlang works traditionally.
   Setting the 'mirror' strategy will essentially combine the other
two strategies such that the remote node reply is forwarded and also
handled locally. This is in some cases more in-line with what some
people might expect, efficiency may vary.
   The traditional 'ignore' approach is more suitable and most likely
originally intended for embedded terminals where 'mirror'-ing the io
is largely unnecessary.