### PR TITLE
Update lager 2.x for OTP 17

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,33 @@
-{erl_opts, [debug_info, warn_untyped_record]}.
+%% -*- erlang -*-
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011-2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 {erl_first_files, ["src/lager_util.erl"]}.
+
+{erl_opts, [
+    debug_info,
+    warn_untyped_record
+]}.
 {deps, [
-        {goldrush, "0\.1\.6",
-            {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.6"}}}
-       ]}.
+    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {branch, "master"}}}
+]}.
 
 {xref_checks, []}.
 {xref_queries, [{"(XC - UC) || (XU - X - B - lager_default_tracer : Mod - erlang:\"(is_map|map_size)\"/1 - maps:to_list/1)", []}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
     warn_untyped_record
 ]}.
 {deps, [
-    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {branch, "master"}}}
+    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.7"}}}
 ]}.
 
 {xref_checks, []}.

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -197,7 +197,7 @@ log_event(Event, State) ->
                     ?LOGFMT(error, Pid, "Webmachine error at path ~p : ~s", [Path, format_reason(StackTrace)]);
                 _ ->
                     ?CRASH_LOG(Event),
-                    ?LOGMSG(error, Pid, lager:safe_format(Fmt, Args, ?DEFAULT_TRUNCATION))
+                    ?LOGFMT(error, Pid, Fmt, Args)
             end;
         {error_report, _GL, {Pid, std_error, D}} ->
             ?CRASH_LOG(Event),
@@ -217,11 +217,11 @@ log_event(Event, State) ->
             ?CRASH_LOG(Event),
             ?LOGMSG(error, Pid, "CRASH REPORT " ++ format_crash_report(Self, Neighbours));
         {warning_msg, _GL, {Pid, Fmt, Args}} ->
-            ?LOGMSG(warning, Pid, lager:safe_format(Fmt, Args, ?DEFAULT_TRUNCATION));
+            ?LOGFMT(warning, Pid, Fmt, Args);
         {warning_report, _GL, {Pid, std_warning, Report}} ->
             ?LOGMSG(warning, Pid, print_silly_list(Report));
         {info_msg, _GL, {Pid, Fmt, Args}} ->
-            ?LOGMSG(info, Pid, lager:safe_format(Fmt, Args, ?DEFAULT_TRUNCATION));
+            ?LOGFMT(info, Pid, Fmt, Args);
         {info_report, _GL, {Pid, std_info, D}} when is_list(D) ->
             Details = lists:sort(D),
             case Details of

--- a/src/lager_backend_throttle.erl
+++ b/src/lager_backend_throttle.erl
@@ -29,6 +29,17 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2,
         code_change/3]).
 
+%%
+%% Allow test code to verify that we're doing the needful.
+-ifdef(TEST).
+-define(ETS_TABLE, async_threshold_test).
+-define(TOGGLE_SYNC(), test_increment(sync_toggled)).
+-define(TOGGLE_ASYNC(), test_increment(async_toggled)).
+-else.
+-define(TOGGLE_SYNC(), true).
+-define(TOGGLE_ASYNC(), true).
+-endif.
+
 -record(state, {
         hwm :: non_neg_integer(),
         window_min :: non_neg_integer(),
@@ -52,10 +63,12 @@ handle_event({log, _Message},State) ->
     case {Len > State#state.hwm, Len < State#state.window_min, State#state.async} of
         {true, _, true} ->
             %% need to flip to sync mode
+            ?TOGGLE_SYNC(),
             lager_config:set(async, false),
             {ok, State#state{async=false}};
         {_, true, false} ->
             %% need to flip to async mode
+            ?TOGGLE_ASYNC(),
             lager_config:set(async, true),
             {ok, State#state{async=true}};
         _ ->
@@ -76,3 +89,16 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+-ifdef(TEST).
+test_get(Key) ->
+    get_default(ets:lookup(?ETS_TABLE, Key)).
+
+test_increment(Key) ->
+    ets:insert(?ETS_TABLE,
+               {Key, test_get(Key) + 1}).
+
+get_default([]) ->
+    0;
+get_default([{_Key, Value}]) ->
+    Value.
+-endif.

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -714,6 +714,11 @@ filesystem_test_() ->
                         {ok, _} = lager:trace_file("foo.log", [{module, ?MODULE}], [{size, 20}, {check_interval, 1}]), 
                         lager:error("Test message"),
                         ?assertNot(filelib:is_regular("foo.log.0")),
+                        %% rotation is sensitive to intervals between
+                        %% writes so we sleep to exceed the 1
+                        %% millisecond interval specified by
+                        %% check_interval above
+                        timer:sleep(2),
                         lager:error("Test message"),
                         timer:sleep(10),
                         ?assert(filelib:is_regular("foo.log.0"))

--- a/test/crash.erl
+++ b/test/crash.erl
@@ -10,8 +10,8 @@
 -export([start/0]).
 
 -record(state, {
-        host,
-        port
+        host :: term(),
+        port :: term()
     }).
 
 start() ->

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1,4 +1,6 @@
-%% Copyright (c) 2011-2012 Basho Technologies, Inc.  All Rights Reserved.
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2011-2015 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -13,6 +15,8 @@
 %% KIND, either express or implied.  See the License for the
 %% specific language governing permissions and limitations
 %% under the License.
+%%
+%% -------------------------------------------------------------------
 
 -module(lager_test_backend).
 
@@ -108,9 +112,17 @@ print_bad_state() ->
 
 has_line_numbers() ->
     %% are we R15 or greater
-    Rel = erlang:system_info(otp_release),
-    {match, [Major]} = re:run(Rel, "(?|(^R(\\d+)[A|B](|0(\\d)))|(^(\\d+)$))", [{capture, [2], list}]),
-    list_to_integer(Major) >= 15.
+    otp_version() >= 15.
+
+otp_version() ->
+    otp_version(erlang:system_info(otp_release)).
+
+otp_version([$R | Rel]) ->
+    {Ver, _} = string:to_integer(Rel),
+    Ver;
+otp_version(Rel) ->
+    {Ver, _} = string:to_integer(Rel),
+    Ver.
 
 not_running_test() ->
     ?assertEqual({error, lager_not_running}, lager:log(info, self(), "not running")).
@@ -607,7 +619,7 @@ error_logger_redirect_crash_test_() ->
                         ?assertEqual(Pid,proplists:get_value(pid,Metadata)),
                         ?assertEqual(lager_util:level_to_num(error),Level)
                 end
-            } 
+            }
     end,
     {foreach,
         fun() ->
@@ -1004,7 +1016,7 @@ error_logger_redirect_test_() ->
                         ?assert(length(lists:flatten(Msg)) < 600)
                 end
             },
-            {"crash reports for 'special processes' should be handled right - function_clause", 
+            {"crash reports for 'special processes' should be handled right - function_clause",
                 fun() ->
                         {ok, Pid} = special_process:start(),
                         unlink(Pid),
@@ -1017,7 +1029,7 @@ error_logger_redirect_test_() ->
                         test_body(Expected, lists:flatten(Msg))
                 end
             },
-            {"crash reports for 'special processes' should be handled right - case_clause", 
+            {"crash reports for 'special processes' should be handled right - case_clause",
                 fun() ->
                         {ok, Pid} = special_process:start(),
                         unlink(Pid),
@@ -1030,7 +1042,7 @@ error_logger_redirect_test_() ->
                         test_body(Expected, lists:flatten(Msg))
                 end
             },
-            {"crash reports for 'special processes' should be handled right - exit", 
+            {"crash reports for 'special processes' should be handled right - exit",
                 fun() ->
                         {ok, Pid} = special_process:start(),
                         unlink(Pid),
@@ -1043,7 +1055,7 @@ error_logger_redirect_test_() ->
                         test_body(Expected, lists:flatten(Msg))
                 end
             },
-            {"crash reports for 'special processes' should be handled right - error", 
+            {"crash reports for 'special processes' should be handled right - error",
                 fun() ->
                         {ok, Pid} = special_process:start(),
                         unlink(Pid),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -751,6 +751,17 @@ error_logger_redirect_test_() ->
                         ?assertEqual(Expected, lists:flatten(Msg))
                 end
             },
+            {"error messages with unicode characters in Args are printed",
+                fun() ->
+                        sync_error_logger:error_msg("~ts", ["Привет!"]),
+                        _ = gen_event:which_handlers(error_logger),
+                        {Level, _, Msg,Metadata} = pop(),
+                        ?assertEqual(lager_util:level_to_num(error),Level),
+                        ?assertEqual(self(),proplists:get_value(pid,Metadata)),
+                        ?assertEqual("Привет!", lists:flatten(Msg))
+                end
+            },
+
             {"error messages are truncated at 4096 characters",
                 fun() ->
                         sync_error_logger:error_msg("doom, doom has come upon you all ~p", [string:copies("doom", 10000)]),
@@ -848,6 +859,27 @@ error_logger_redirect_test_() ->
                         ?assertEqual(lager_util:level_to_num(info),Level),
                         ?assertEqual(self(),proplists:get_value(pid,Metadata)),
                         ?assert(length(lists:flatten(Msg)) < 5100)
+                end
+            },
+            {"info messages with unicode characters in Args are printed",
+                fun() ->
+                        sync_error_logger:info_msg("~ts", ["Привет!"]),
+                        _ = gen_event:which_handlers(error_logger),
+                        {Level, _, Msg,Metadata} = pop(),
+                        ?assertEqual(lager_util:level_to_num(info),Level),
+                        ?assertEqual(self(),proplists:get_value(pid,Metadata)),
+                        ?assertEqual("Привет!", lists:flatten(Msg))
+                end
+            },
+            {"warning messages with unicode characters in Args are printed",
+                fun() ->
+                        sync_error_logger:warning_msg("~ts", ["Привет!"]),
+                        Map = error_logger:warning_map(),
+                        _ = gen_event:which_handlers(error_logger),
+                        {Level, _, Msg,Metadata} = pop(),
+                        ?assertEqual(lager_util:level_to_num(Map),Level),
+                        ?assertEqual(self(),proplists:get_value(pid,Metadata)),
+                        ?assertEqual("Привет!", lists:flatten(Msg))
                 end
             },
 

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1233,6 +1233,9 @@ async_threshold_test_() ->
     {foreach,
         fun() ->
                 error_logger:tty(false),
+                ets:new(async_threshold_test, [set, named_table, public]),
+                ets:insert_new(async_threshold_test, {sync_toggled, 0}),
+                ets:insert_new(async_threshold_test, {async_toggled, 0}),
                 application:load(lager),
                 application:set_env(lager, error_logger_redirect, false),
                 application:set_env(lager, async_threshold, 2),
@@ -1244,6 +1247,7 @@ async_threshold_test_() ->
                 application:unset_env(lager, async_threshold),
                 application:stop(lager),
                 application:stop(goldrush),
+                ets:delete(async_threshold_test),
                 error_logger:tty(true)
         end,
         [
@@ -1258,11 +1262,22 @@ async_threshold_test_() ->
                         %% serialize on mailbox
                         _ = gen_event:which_handlers(lager_event),
                         timer:sleep(500),
-                        %% there should be a ton of outstanding messages now, so async is false
-                        ?assertEqual(false, lager_config:get(async)),
-                        %% wait for all the workers to return, meaning that all the messages have been logged (since we're in sync mode)
+
+                        %% By now the flood of messages will have
+                        %% forced the backend throttle to turn off
+                        %% async mode, but it's possible all
+                        %% outstanding requests have been processed,
+                        %% so checking the current status (sync or
+                        %% async) is an exercise in race control.
+
+                        %% Instead, we'll see whether the backend
+                        %% throttle has toggled into sync mode at any
+                        %% point in the past
+                        ?assertMatch([{sync_toggled, N}] when N > 0,
+                                                              ets:lookup(async_threshold_test, sync_toggled)),
+                        %% wait for all the workers to return, meaning that all the messages have been logged (since we're definitely in sync mode at the end of the run)
                         collect_workers(Workers),
-                        %% serialize ont  the mailbox again
+                        %% serialize on the mailbox again
                         _ = gen_event:which_handlers(lager_event),
                         %% just in case...
                         timer:sleep(1000),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -27,8 +27,8 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2,
         code_change/3]).
 
--record(state, {level, buffer, ignored}).
--record(test, {attrs, format, args}).
+-record(state, {level :: list(), buffer :: list(), ignored :: list()}).
+-record(test, {attrs :: term(), format :: term() , args :: term()}).
 -compile([{parse_transform, lager_transform}]).
 
 -ifdef(TEST).

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -112,7 +112,15 @@ print_bad_state() ->
 
 has_line_numbers() ->
     %% are we R15 or greater
-    otp_version() >= 15.
+    % this gets called a LOT - cache the answer
+    case erlang:get({?MODULE, has_line_numbers}) of
+        undefined ->
+            R = otp_version() >= 15,
+            erlang:put({?MODULE, has_line_numbers}, R),
+            R;
+        Bool ->
+            Bool
+    end.
 
 otp_version() ->
     otp_version(erlang:system_info(otp_release)).
@@ -591,20 +599,42 @@ crash(Type) ->
 test_body(Expected, Actual) ->
     case has_line_numbers() of
         true ->
-            FileLine = string:substr(Actual, length(Expected)+1),
-            Body = string:substr(Actual, 1, length(Expected)),
+            ExLen = length(Expected),
+            {Body, Rest} = case length(Actual) > ExLen of
+                true ->
+                    {string:substr(Actual, 1, ExLen),
+                        string:substr(Actual, (ExLen + 1))};
+                _ ->
+                    {Actual, []}
+            end,
             ?assertEqual(Expected, Body),
-            case string:substr(FileLine, 1, 6) of
+            % OTP-17 (and maybe later releases) may tack on additional info
+            % about the failure, so if Actual starts with Expected (already
+            % confirmed by having gotten past assertEqual above) and ends
+            % with " line NNN" we can ignore what's in-between. By extension,
+            % since there may not be line information appended at all, any
+            % text we DO find is reportable, but not a test failure.
+            case Rest of
                 [] ->
-                    %% sometimes there's no line information...
-                    ?assert(true);
-                " line " ->
-                    ?assert(true);
-                Other ->
-                    ?debugFmt("unexpected trailing data ~p", [Other]),
-                    ?assert(false)
+                    ok;
+                _ ->
+                    % isolate the extra data and report it if it's not just
+                    % a line number indicator
+                    case re:run(Rest, "^.*( line \\d+)$", [{capture, [1]}]) of
+                        nomatch ->
+                            ?debugFmt(
+                                "Trailing data \"~s\" following \"~s\"",
+                                [Rest, Expected]);
+                        {match, [{0, _}]} ->
+                            % the whole sting is " line NNN"
+                            ok;
+                        {match, [{Off, _}]} ->
+                            ?debugFmt(
+                                "Trailing data \"~s\" following \"~s\"",
+                                [string:substr(Rest, 1, Off), Expected])
+                    end
             end;
-        false ->
+        _ ->
             ?assertEqual(Expected, Actual)
     end.
 

--- a/test/pr_nested_record_test.erl
+++ b/test/pr_nested_record_test.erl
@@ -2,13 +2,11 @@
 
 -compile([{parse_transform, lager_transform}]).
 
--record(a, {field1, field2}).
--record(b, {field1, field2}).
+-record(a, {field1 :: term(), field2 :: term()}).
+-record(b, {field1 :: term() , field2 :: term()}).
 
 
--ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
 
 nested_record_test() ->
     A = #a{field1 = x, field2 = y}, 


### PR DESCRIPTION
Includes several test failure fixes, a Unicode bug fix and updates goldrush to release 0.1.7.

The 2.x branch is a maintenance branch intended for lager users who do not wish to use the lager 3.0 code or its API semantics.