### PR TITLE
Add an unsafe_formatting code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Features
 * Rewrites common OTP error messages into more readable messages
 * Support for pretty printing records encountered at compile time
 * Tolerant in the face of large or many log messages, won't out of memory the node
+* Optional feature to bypass log size truncation ("unsafe")
 * Supports internal time and date based rotation, as well as external rotation tools
 * Syslog style log level comparison flags
 * Colored terminal output (requires R16+)
@@ -262,6 +263,30 @@ related processes crash, you can set a limit:
 ```
 
 It is probably best to keep this number small.
+
+"Unsafe"
+--------
+The unsafe code pathway bypasses the normal lager formatting code and uses the
+same code as error_logger in OTP. This provides a marginal speedup to your logging
+code (we measured between 0.5-1.3% improvement during our benchmarking; others have
+reported better improvements.)
+
+This is a **dangerous** feature. It *will not* protect you against
+large log messages - large messages can kill your application and even your
+Erlang VM dead due to memory exhaustion as large terms are copied over and
+over in a failure cascade.  We strongly recommend that this code pathway
+only be used by log messages with a well bounded upper size of around 500 bytes.
+
+If there's any possibility the log messages could exceed that limit, you should
+use the normal lager message formatting code which will provide the appropriate
+size limitations and protection against memory exhaustion.
+
+If you want to format an unsafe log message, you may use the severity level (as
+usual) followed by `_unsafe`. Here's an example:
+
+```erlang
+lager:info_unsafe("The quick brown ~s jumped over the lazy ~s", ["fox", "dog"]).
+```
 
 Runtime loglevel changes
 ------------------------

--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -25,7 +25,7 @@
 %% Use of these "functions" means that the argument list will not be
 %% truncated for safety
 -define(LEVELS_UNSAFE,
-    [debug_unsafe, info_unsafe, notice_unsafe, warning_unsafe, error_unsafe, critical_unsafe, alert_unsafe, emergency_unsafe]).
+    [{debug_unsafe, debug}, {info_unsafe, info}, {notice_unsafe, notice}, {warning_unsafe, warning}, {error_unsafe, error}, {critical_unsafe, critical}, {alert_unsafe, alert}, {emergency_unsafe, emergency}]).
 
 -define(DEBUG, 128).
 -define(INFO, 64).

--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -22,6 +22,11 @@
 -define(LEVELS,
     [debug, info, notice, warning, error, critical, alert, emergency, none]).
 
+%% Use of these "functions" means that the argument list will not be
+%% truncated for safety
+-define(LEVELS_UNSAFE,
+    [debug_unsafe, info_unsafe, notice_unsafe, warning_unsafe, error_unsafe, critical_unsafe, alert_unsafe, emergency_unsafe]).
+
 -define(DEBUG, 128).
 -define(INFO, 64).
 -define(NOTICE, 32).
@@ -64,7 +69,7 @@
             Level,
             [{pid,Pid},{line,?LINE},{file,?FILE},{module,?MODULE}],
             [])}
-        )). 
+        )).
 
 %% FOR INTERNAL USE ONLY
 %% internal non-blocking logging call
@@ -102,14 +107,14 @@
 -endif.
 
 -record(lager_shaper, {
-		  %% how many messages per second we try to deliver
-		  hwm = undefined :: 'undefined' | pos_integer(),
-		  %% how many messages we've received this second
-		  mps = 0 :: non_neg_integer(),
-		  %% the current second
-		  lasttime = os:timestamp() :: erlang:timestamp(),
-		  %% count of dropped messages this second
-		  dropped = 0 :: non_neg_integer()
-		 }).
+                  %% how many messages per second we try to deliver
+                  hwm = undefined :: 'undefined' | pos_integer(),
+                  %% how many messages we've received this second
+                  mps = 0 :: non_neg_integer(),
+                  %% the current second
+                  lasttime = os:timestamp() :: erlang:timestamp(),
+                  %% count of dropped messages this second
+                  dropped = 0 :: non_neg_integer()
+                 }).
 
 -type lager_shaper() :: #lager_shaper{}.

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -98,9 +98,6 @@ dispatch_log(Sink, Severity, Metadata, Format, Args, Size) when is_atom(Severity
 
 %% @private Should only be called externally from code generated from the parse transform
 do_log(Severity, Metadata, Format, Args, Size, SeverityAsInt, LevelThreshold, TraceFilters, Sink, SinkPid) when is_atom(Severity) ->
-    %% XXX FIXME : DO NOT RELEASE
-    %% If you use the unsafe fun, make sure to underscore the _Size variable in the function head.
-    %FormatFun = fun() -> unsafe_format(Format, Args) end,
     FormatFun = fun() -> safe_format_chop(Format, Args, Size) end,
     do_log_impl(Severity, Metadata, Format, Args, SeverityAsInt, LevelThreshold, TraceFilters, Sink, SinkPid, FormatFun).
 

--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -89,10 +89,10 @@ transform_statement({call, Line, {remote, _Line1, {atom, _Line2, Module},
                     SinkName = list_to_atom(atom_to_list(Module) ++ "_event"),
                     do_transform(Line, SinkName, Function, Arguments0);
                 false ->
-                    case lists:member(Function, ?LEVELS_UNSAFE) of
-                        true ->
+                    case lists:keyfind(Function, 1, ?LEVELS_UNSAFE) of
+                        {Function, Severity} ->
                             SinkName = list_to_atom(atom_to_list(Module) ++ "_event"),
-                            do_transform(Line, SinkName, Function, Arguments0, unsafe);
+                            do_transform(Line, SinkName, Severity, Arguments0, unsafe);
                         false ->
                             Stmt
                     end


### PR DESCRIPTION
This branch adds a new `_unsafe` path for log messages with a reasonable bounded size when its not necessary for lager to ensure that log messages don't kill an application because they're so huge.