### PR TITLE
Extend lager_msg with format and args

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -120,7 +120,7 @@ do_log_impl(Severity, Metadata, Format, Args, SeverityAsInt, LevelThreshold, Tra
                     Format
             end,
             LagerMsg = lager_msg:new(Msg,
-                Severity, Metadata, Destinations),
+                Severity, Metadata, Destinations, Format, Args),
             case lager_config:get({Sink, async}, false) of
                 true ->
                     gen_event:notify(SinkPid, {log, LagerMsg});


### PR DESCRIPTION
Hello guys. I want to add extra fields (format and args) to lager_msg to be able to evaluate formatting in lager backend module.

It can be useful when backend module want to process it differently against io_lib:format