### PR TITLE
Accept 255 (or 0xFF in hexadecimal) for format strings

### DIFF
--- a/src/lager_stdlib.erl
+++ b/src/lager_stdlib.erl
@@ -39,7 +39,7 @@ string_p([]) ->
 string_p(Term) ->
     string_p1(Term).
 
-string_p1([H|T]) when is_integer(H), H >= $\s, H < 255 ->
+string_p1([H|T]) when is_integer(H), H >= $\s, H < 256 ->
     string_p1(T);
 string_p1([$\n|T]) -> string_p1(T);
 string_p1([$\r|T]) -> string_p1(T);

--- a/test/trunc_io_eqc.erl
+++ b/test/trunc_io_eqc.erl
@@ -91,7 +91,7 @@ gen_fmt_args() ->
 
 %% Generates a printable string
 gen_print_str() ->
-    ?LET(Xs, list(char()), [X || X <- Xs, io_lib:printable_list([X]), X /= $~, X < 255]).
+    ?LET(Xs, list(char()), [X || X <- Xs, io_lib:printable_list([X]), X /= $~, X < 256]).
 
 gen_print_bin() ->
     ?LET(Xs, gen_print_str(), list_to_binary(Xs)).


### PR DESCRIPTION
At least for ISO 8859-1 (aka Latin-1) [1], 255 is one of its
characters.

Behavior before this commit:

```
9> lager:log(info, self(), ["254 is ok: ", 254]).
ok
17:55:11.624 [info] 254 is ok: þÿ
10> lager:log(info, self(), ["255 is not considered as \"character\" (sadpanda)", 255]).
ok
17:55:15.080 [info] FORMAT ERROR: ["255 is not considered as \"character\" (sadpanda)",255] []
```

[1] https://en.wikipedia.org/wiki/ISO/IEC_8859-1
