### PR TITLE
Add option to format output with Width param in lager_default_formatter

### DIFF
--- a/src/lager_default_formatter.erl
+++ b/src/lager_default_formatter.erl
@@ -320,7 +320,7 @@ basic_test_() ->
                         [{metadata, "->", ", "}]
                     )))
         },
-        {"Metadata can have extra formatting with weidth1",
+        {"Metadata can have extra formatting with width 1",
             ?_assertEqual(iolist_to_binary(["(hello     )"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,
@@ -330,7 +330,7 @@ basic_test_() ->
                     ["(",{pid, [pid], "", 10},")"]
                 )))
         },
-        {"Metadata can have extra formatting with weidth2",
+        {"Metadata can have extra formatting with width 2",
             ?_assertEqual(iolist_to_binary(["(hello     )"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,
@@ -340,7 +340,7 @@ basic_test_() ->
                     ["(",{pid, [pid], "", {left,10}},")"]
                 )))
         },
-        {"Metadata can have extra formatting with weidth3",
+        {"Metadata can have extra formatting with width 3",
             ?_assertEqual(iolist_to_binary(["(     hello)"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,
@@ -350,7 +350,7 @@ basic_test_() ->
                     ["(",{pid, [pid], "", {right,10}},")"]
                 )))
         },
-        {"Metadata can have extra formatting with weidth4",
+        {"Metadata can have extra formatting with width 4",
             ?_assertEqual(iolist_to_binary(["(  hello   )"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,
@@ -360,7 +360,7 @@ basic_test_() ->
                     ["(",{pid, [pid], "", {centre,10}},")"]
                 )))
         },
-        {"Metadata can have extra formatting with weidth5",
+        {"Metadata can have extra formatting with width 5",
             ?_assertEqual(iolist_to_binary(["error     |hello     ! (  hello   )"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,
@@ -370,7 +370,7 @@ basic_test_() ->
                     [{x,"",[severity,{blank,"|"},pid], 10},"!",blank,"(",{pid, [pid], "", {centre,10}},")"]
                 )))
         },
-        {"Metadata can have extra formatting with weidth6",
+        {"Metadata can have extra formatting with width 6",
             ?_assertEqual(iolist_to_binary([Time,Date," bar=2 baz=3 foo=1 pid=hello EMessage"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,

--- a/src/lager_default_formatter.erl
+++ b/src/lager_default_formatter.erl
@@ -181,7 +181,7 @@ make_printable(A,{Align,W}) when is_integer(W) ->
             string:left(make_printable(A),W)
     end;
 
-make_printable(A,_W) -> string:right(make_printable(A)).
+make_printable(A,_W) -> make_printable(A).
 
 get_metadata(Key, Metadata) ->
     get_metadata(Key, Metadata, undefined).
@@ -321,13 +321,17 @@ basic_test_() ->
                     )))
         },
         {"Metadata can have extra formatting with width 1",
-            ?_assertEqual(iolist_to_binary(["(hello     )"]),
+            ?_assertEqual(iolist_to_binary(["(hello     )(hello     )(hello)(hello)(hello)"]),
                 iolist_to_binary(format(lager_msg:new("Message",
                     Now,
                     error,
                     [{pid, hello}],
                     []),
-                    ["(",{pid, [pid], "", 10},")"]
+                    ["(",{pid, [pid], "", 10},")",
+                        "(",{pid, [pid], "", {bad_align,10}},")",
+                        "(",{pid, [pid], "", bad10},")",
+                        "(",{pid, [pid], "", {right,bad20}},")",
+                        "(",{pid, [pid], "", {bad_align,bad20}},")"]
                 )))
         },
         {"Metadata can have extra formatting with width 2",

--- a/src/lager_default_formatter.erl
+++ b/src/lager_default_formatter.erl
@@ -86,6 +86,10 @@ output(time,Msg) ->
     T;
 output(severity,Msg) ->
     atom_to_list(lager_msg:severity(Msg));
+output(blank,_Msg) ->
+    output({blank," "},_Msg);
+output({blank,Fill},_Msg) ->
+    Fill;
 output(sev,Msg) ->
     %% Write brief acronym for the severity level (e.g. debug -> $D)
     [lager_util:level_to_chr(lager_msg:severity(Msg))];
@@ -109,7 +113,46 @@ output({Prop, Present, Absent}, Msg) when is_atom(Prop) ->
         _ ->
             [ output(V, Msg) || V <- Present]
     end;
+output({Prop, Present, Absent, Width}, Msg) when is_atom(Prop) ->
+    %% sort of like a poor man's ternary operator
+    Metadata = lager_msg:metadata(Msg),
+    case get_metadata(Prop, Metadata) of
+        undefined ->
+            [ output(V, Msg, Width) || V <- Absent];
+        _ ->
+            [ output(V, Msg, Width) || V <- Present]
+    end;
 output(Other,_) -> make_printable(Other).
+
+output(message, Msg, _Width) -> lager_msg:message(Msg);
+output(date,Msg, _Width) ->
+    {D, _T} = lager_msg:datetime(Msg),
+    D;
+output(time, Msg, _Width) ->
+    {_D, T} = lager_msg:datetime(Msg),
+    T;
+output(severity, Msg, Width) ->
+    make_printable(atom_to_list(lager_msg:severity(Msg)), Width);
+output(sev,Msg, _Width) ->
+    %% Write brief acronym for the severity level (e.g. debug -> $D)
+    [lager_util:level_to_chr(lager_msg:severity(Msg))];
+output(blank,_Msg, _Width) ->
+    output({blank, " "},_Msg, _Width);
+output({blank, Fill},_Msg, _Width) ->
+    Fill;
+output(metadata, Msg, _Width) ->
+    output({metadata, "=", " "}, Msg, _Width);
+output({metadata, IntSep, FieldSep}, Msg, _Width) ->
+    MD = lists:keysort(1, lager_msg:metadata(Msg)),
+    [string:join([io_lib:format("~s~s~p", [K, IntSep, V]) || {K, V} <- MD], FieldSep)];
+
+output(Prop, Msg, Width) when is_atom(Prop) ->
+    Metadata = lager_msg:metadata(Msg),
+    make_printable(get_metadata(Prop,Metadata,<<"Undefined">>), Width);
+output({Prop,Default},Msg, Width) when is_atom(Prop) ->
+    Metadata = lager_msg:metadata(Msg),
+    make_printable(get_metadata(Prop,Metadata,output(Default,Msg)), Width);
+output(Other,_, Width) -> make_printable(Other, Width).
 
 output_color(_Msg,[]) -> [];
 output_color(Msg,Colors) ->
@@ -124,6 +167,21 @@ make_printable(A) when is_atom(A) -> atom_to_list(A);
 make_printable(P) when is_pid(P) -> pid_to_list(P);
 make_printable(L) when is_list(L) orelse is_binary(L) -> L; 
 make_printable(Other) -> io_lib:format("~p",[Other]).
+
+make_printable(A,W) when is_integer(W)-> string:left(make_printable(A),W);
+make_printable(A,{Align,W}) when is_integer(W) ->
+    case Align of
+        left ->
+            string:left(make_printable(A),W);
+        centre ->
+            string:centre(make_printable(A),W);
+        right ->
+            string:right(make_printable(A),W);
+        _ ->
+            string:left(make_printable(A),W)
+    end;
+
+make_printable(A,_W) -> string:right(make_printable(A)).
 
 get_metadata(Key, Metadata) ->
     get_metadata(Key, Metadata, undefined).
@@ -261,7 +319,71 @@ basic_test_() ->
                             []),
                         [{metadata, "->", ", "}]
                     )))
+        },
+        {"Metadata can have extra formatting with weidth1",
+            ?_assertEqual(iolist_to_binary(["(hello     )"]),
+                iolist_to_binary(format(lager_msg:new("Message",
+                    Now,
+                    error,
+                    [{pid, hello}],
+                    []),
+                    ["(",{pid, [pid], "", 10},")"]
+                )))
+        },
+        {"Metadata can have extra formatting with weidth2",
+            ?_assertEqual(iolist_to_binary(["(hello     )"]),
+                iolist_to_binary(format(lager_msg:new("Message",
+                    Now,
+                    error,
+                    [{pid, hello}],
+                    []),
+                    ["(",{pid, [pid], "", {left,10}},")"]
+                )))
+        },
+        {"Metadata can have extra formatting with weidth3",
+            ?_assertEqual(iolist_to_binary(["(     hello)"]),
+                iolist_to_binary(format(lager_msg:new("Message",
+                    Now,
+                    error,
+                    [{pid, hello}],
+                    []),
+                    ["(",{pid, [pid], "", {right,10}},")"]
+                )))
+        },
+        {"Metadata can have extra formatting with weidth4",
+            ?_assertEqual(iolist_to_binary(["(  hello   )"]),
+                iolist_to_binary(format(lager_msg:new("Message",
+                    Now,
+                    error,
+                    [{pid, hello}],
+                    []),
+                    ["(",{pid, [pid], "", {centre,10}},")"]
+                )))
+        },
+        {"Metadata can have extra formatting with weidth5",
+            ?_assertEqual(iolist_to_binary(["error     |hello     ! (  hello   )"]),
+                iolist_to_binary(format(lager_msg:new("Message",
+                    Now,
+                    error,
+                    [{pid, hello}],
+                    []),
+                    [{x,"",[severity,{blank,"|"},pid], 10},"!",blank,"(",{pid, [pid], "", {centre,10}},")"]
+                )))
+        },
+        {"Metadata can have extra formatting with weidth6",
+            ?_assertEqual(iolist_to_binary([Time,Date," bar=2 baz=3 foo=1 pid=hello EMessage"]),
+                iolist_to_binary(format(lager_msg:new("Message",
+                    Now,
+                    error,
+                    [{pid, hello},{foo, 1}, {bar, 2}, {baz, 3}],
+                    []),
+                    [{x,"",[time]}, {x,"",[date],20},blank,{x,"",[metadata],30},blank,{x,"",[sev],10},message, {message,message,"", {right,20}}]
+                )))
         }
+
+
+
+
     ].
 
 -endif.


### PR DESCRIPTION
`Width :: integer() | {left  | right | centre, integer()}`
placeholders: date, time, message, sev, metadata and new placeholder `blank::blank | {blank, string()}` ignore Width param
example :
* `["[",{undef, "", [severity], {right, 10}},"]"] ->`    if severity is error  print [&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;error]
* `["[",{undef, "", [severity], {left, 10}},"]"] ->`      if severity is error  print [error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]
* `["[",{undef, "", [severity], {centre, 10}},"]"] ->` if severity is error  print [&nbsp;&nbsp;error&nbsp;&nbsp;&nbsp;]
* `["[",{undef, "", [severity], 10},"]"] ->`               if severity is error  print [error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]
* `["[",{undef, "", [severity,{blank,"|"},severity], {left, 10}},"]"] ->`   if severity is error  print [error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]
* `["[",{undef, "", [severity,"|",severity], {left, 10}},"]"] ->`   if severity is error  print [error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;error&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]
