### PR TITLE
Forward port #292 to 3.x branch

### DIFF
--- a/src/lager_stdlib.erl
+++ b/src/lager_stdlib.erl
@@ -39,7 +39,7 @@ string_p([]) ->
 string_p(Term) ->
     string_p1(Term).
 
-string_p1([H|T]) when is_integer(H), H >= $\s, H < 255 ->
+string_p1([H|T]) when is_integer(H), H >= $\s, H < 256 ->
     string_p1(T);
 string_p1([$\n|T]) -> string_p1(T);
 string_p1([$\r|T]) -> string_p1(T);

--- a/test/trunc_io_eqc.erl
+++ b/test/trunc_io_eqc.erl
@@ -91,7 +91,7 @@ gen_fmt_args() ->
 
 %% Generates a printable string
 gen_print_str() ->
-    ?LET(Xs, list(char()), [X || X <- Xs, io_lib:printable_list([X]), X /= $~, X < 255]).
+    ?LET(Xs, list(char()), [X || X <- Xs, io_lib:printable_list([X]), X /= $~, X < 256]).
 
 gen_print_bin() ->
     ?LET(Xs, gen_print_str(), list_to_binary(Xs)).


### PR DESCRIPTION
255 is a valid ISO-8859-1 character. This was fixed on 2.x by #292. Forward port the fix into 3.x.