### PR TITLE
Option to not reformat error_logger messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Lager is also supplied with a `error_logger` handler module that translates
 traditional erlang error messages into a friendlier format and sends them into
 lager itself to be treated like a regular lager log call. To disable this, set
 the lager application variable `error_logger_redirect` to `false`.
-You can also disable reformating for OTP and Cowboy messages by setting variable
+You can also disable reformatting for OTP and Cowboy messages by setting variable
 `error_logger_format_raw` to `true`.
 
 The `error_logger` handler will also log more complete error messages (protected

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Lager is also supplied with a `error_logger` handler module that translates
 traditional erlang error messages into a friendlier format and sends them into
 lager itself to be treated like a regular lager log call. To disable this, set
 the lager application variable `error_logger_redirect` to `false`.
+You can also disable reformating for OTP and Cowboy messages by setting variable
+`error_logger_format_raw` to `true`.
 
 The `error_logger` handler will also log more complete error messages (protected
 with use of `trunc_io`) to a "crash log" which can be referred to for further

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -37,7 +37,8 @@
         sink :: atom(),
         shaper :: lager_shaper(),
         %% group leader strategy
-        groupleader_strategy :: handle | ignore | mirror
+        groupleader_strategy :: handle | ignore | mirror,
+        raw :: boolean()
     }).
 
 -define(LOGMSG(Sink, Level, Pid, Msg),
@@ -72,8 +73,9 @@ set_high_water(N) ->
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
     Shaper = #lager_shaper{hwm=HighWaterMark},
+    Raw = application:get_env(lager, error_logger_format_raw, false),
     Sink = configured_sink(),
-    {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy}}.
+    {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy, raw=Raw}}.
 
 handle_call({set_high_water, N}, #state{shaper=Shaper} = State) ->
     NewShaper = Shaper#lager_shaper{hwm=N},
@@ -100,8 +102,18 @@ handle_info(_Info, State) ->
 terminate(_Reason, _State) ->
     ok.
 
+
 code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
-    {ok, #state{sink=configured_sink(), shaper=Shaper, groupleader_strategy=GLStrategy}};
+    Raw = application:get_env(lager, error_logger_format_raw, false),
+    {ok, #state{
+        sink=configured_sink(), 
+        shaper=Shaper, 
+        groupleader_strategy=GLStrategy, 
+        raw=Raw
+        }};
+code_change(_OldVsn, {state, Sink, Shaper, GLS}, _Extra) ->
+    Raw = application:get_env(lager, error_logger_format_raw, false),
+    {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GLS, raw=Raw}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
@@ -130,7 +142,7 @@ eval_gl(Event, State) ->
 log_event(Event, #state{sink=Sink} = State) ->
     case Event of
         {error, _GL, {Pid, Fmt, Args}} ->
-            FormatRaw = application:get_env(lager, error_logger_format_raw, false),
+            FormatRaw = State#state.raw,
             case {FormatRaw, Fmt} of
                 {false, "** Generic server "++_} ->
                     %% gen_server terminate

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -131,7 +131,7 @@ log_event(Event, #state{sink=Sink} = State) ->
     case Event of
         {error, _GL, {Pid, Fmt, Args}} ->
             FormatRaw = application:get_env(lager, error_logger_format_raw, false),
-            case Fmt of
+            case {FormatRaw, Fmt} of
                 {false, "** Generic server "++_} ->
                     %% gen_server terminate
                     [Name, _Msg, _State, Reason] = Args,

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -130,26 +130,27 @@ eval_gl(Event, State) ->
 log_event(Event, #state{sink=Sink} = State) ->
     case Event of
         {error, _GL, {Pid, Fmt, Args}} ->
+            FormatRaw = application:get_env(lager, error_logger_format_raw, false),
             case Fmt of
-                "** Generic server "++_ ->
+                {false, "** Generic server "++_} ->
                     %% gen_server terminate
                     [Name, _Msg, _State, Reason] = Args,
                     ?CRASH_LOG(Event),
                     ?LOGFMT(Sink, error, Pid, "gen_server ~w terminated with reason: ~s",
                         [Name, format_reason(Reason)]);
-                "** State machine "++_ ->
+                {false, "** State machine "++_} ->
                     %% gen_fsm terminate
                     [Name, _Msg, StateName, _StateData, Reason] = Args,
                     ?CRASH_LOG(Event),
                     ?LOGFMT(Sink, error, Pid, "gen_fsm ~w in state ~w terminated with reason: ~s",
                         [Name, StateName, format_reason(Reason)]);
-                "** gen_event handler"++_ ->
+                {false, "** gen_event handler"++_} ->
                     %% gen_event handler terminate
                     [ID, Name, _Msg, _State, Reason] = Args,
                     ?CRASH_LOG(Event),
                     ?LOGFMT(Sink, error, Pid, "gen_event ~w installed in ~w terminated with reason: ~s",
                         [ID, Name, format_reason(Reason)]);
-                "** Cowboy handler"++_ ->
+                {false, "** Cowboy handler"++_} ->
                     %% Cowboy HTTP server error
                     ?CRASH_LOG(Event),
                     case Args of
@@ -165,7 +166,7 @@ log_event(Event, #state{sink=Sink} = State) ->
                                 "Cowboy handler ~p terminated in ~p:~p/~p with reason: ~s",
                                 [Module, Module, Function, Arity, format_reason({Reason, StackTrace})])
                     end;
-                "Ranch listener "++_ ->
+                {false, "Ranch listener "++_} ->
                     %% Ranch errors
                     ?CRASH_LOG(Event),
                     case Args of
@@ -178,7 +179,7 @@ log_event(Event, #state{sink=Sink} = State) ->
                                 "Ranch listener ~p terminated with reason: ~s",
                                 [Ref, format_reason(Reason)])
                     end;
-                "webmachine error"++_ ->
+                {false, "webmachine error"++_} ->
                     %% Webmachine HTTP server error
                     ?CRASH_LOG(Event),
                     [Path, Error] = Args,

--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -47,6 +47,8 @@
             {error_logger_redirect, true},
             %% How many messages per second to allow from error_logger before we start dropping them
             {error_logger_hwm, 50},
+            %% Whether to reformat OTP and Cowboy messages, or use format from event
+            {error_logger_format_raw, false},
             %% How big the gen_event mailbox can get before it is
             %% switched into sync mode.  This value only applies to
             %% the default sink; extra sinks can supply their own.

--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -47,8 +47,6 @@
             {error_logger_redirect, true},
             %% How many messages per second to allow from error_logger before we start dropping them
             {error_logger_hwm, 50},
-            %% Whether to reformat OTP and Cowboy messages, or use format from event
-            {error_logger_format_raw, false},
             %% How big the gen_event mailbox can get before it is
             %% switched into sync mode.  This value only applies to
             %% the default sink; extra sinks can supply their own.


### PR DESCRIPTION
Application variable `error_logger_format_raw` when set to `true` prevents error_logger messages from reformatting.