### PR TITLE
Fix internal tuple argument order

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -294,7 +294,10 @@ stop_trace_int({_Filter, _Level, Backend} = Trace, Sink) ->
             %% check no other traces point here
             case lists:keyfind(Backend, 3, NewTraces) of
                 false ->
-                    gen_event:delete_handler(Sink, Backend, []);
+                    gen_event:delete_handler(Sink, Backend, []),
+                    lager_config:global_set(handlers,
+                                            lists:keydelete(Backend, 1,
+                                                            lager_config:global_get(handlers)));
                 _ ->
                     ok
             end;


### PR DESCRIPTION
As identified in PR #267, the argument ordering in the internal representation of a trace tuple as returned by `validate_trace_filters` is different from the external representation, and we had the external ordering in the function head.

This prevented backends from being stopped or removed if no other traces were active for that backend.