### PR TITLE
API to explicitly call log rotation

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -28,6 +28,7 @@
         log/3, log/4, log/5,
         log_unsafe/4,
         md/0, md/1,
+        rotate_file/1, rotate_sink/1, rotate_all/0,
         trace/2, trace/3, trace_file/2, trace_file/3, trace_file/4, trace_console/1, trace_console/2,
         list_all_sinks/0, clear_all_traces/0, stop_trace/1, stop_trace/3, status/0,
         get_loglevel/1, get_loglevel/2, set_loglevel/2, set_loglevel/3, set_loglevel/4, get_loglevels/1,
@@ -594,3 +595,26 @@ pr_stacktrace(Stacktrace) ->
 pr_stacktrace(Stacktrace, {Class, Reason}) ->
     lists:flatten(
         pr_stacktrace(Stacktrace) ++ "\n" ++ io_lib:format("~s:~p", [Class, Reason])).
+
+rotate_file(FileName) ->
+    Handlers = lager_config:global_get(handlers),
+    RotateHandlers = lists:filter(
+        fun ({{lager_file_backend, FN}, _, _}) ->
+                FN == FileName orelse 
+                lager_util:expand_path(FN) == lager_util:expand_path(FileName);
+            (_) -> false
+        end,
+        Handlers),
+    lager_file_backend:rotate_handlers(RotateHandlers).
+
+rotate_sink(Sink) ->
+    Handlers = lager_config:global_get(handlers),
+    RotateHandlers = lists:filter(
+        fun({_,_,S}) -> S == Sink; 
+           (_) -> false 
+        end, 
+        Handlers),
+    lager_file_backend:rotate_handlers(RotateHandlers).
+
+rotate_all() -> 
+    lager_file_backend:rotate_handlers(lager_config:global_get(handlers)).

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -605,7 +605,7 @@ rotate_file(FileName) ->
             (_) -> false
         end,
         Handlers),
-    lager_file_backend:rotate_handlers(RotateHandlers).
+    rotate_handlers(RotateHandlers).
 
 rotate_sink(Sink) ->
     Handlers = lager_config:global_get(handlers),
@@ -614,7 +614,15 @@ rotate_sink(Sink) ->
            (_) -> false 
         end, 
         Handlers),
-    lager_file_backend:rotate_handlers(RotateHandlers).
+    rotate_handlers(RotateHandlers).
 
 rotate_all() -> 
-    lager_file_backend:rotate_handlers(lager_config:global_get(handlers)).
+    rotate_handlers(lager_config:global_get(handlers)).
+
+
+rotate_handlers(Handlers) ->
+    [ rotate_handler(Handler) || Handler <- Handlers ].
+
+rotate_handler({Backend, Handler, Sink}) ->
+    gen_event:call(Sink, Backend, rotate, infinity).
+

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -22,13 +22,14 @@
 
 -define(LAGER_MD_KEY, '__lager_metadata').
 -define(TRACE_SINK, '__trace_sink').
+-define(ROTATE_TIMEOUT, 100000).
 
 %% API
 -export([start/0,
         log/3, log/4, log/5,
         log_unsafe/4,
         md/0, md/1,
-        rotate_file/1, rotate_sink/1, rotate_all/0,
+        rotate_handler/1, rotate_handler/2, rotate_sink/1, rotate_all/0,
         trace/2, trace/3, trace_file/2, trace_file/3, trace_file/4, trace_console/1, trace_console/2,
         list_all_sinks/0, clear_all_traces/0, stop_trace/1, stop_trace/3, status/0,
         get_loglevel/1, get_loglevel/2, set_loglevel/2, set_loglevel/3, set_loglevel/4, get_loglevels/1,
@@ -595,34 +596,31 @@ pr_stacktrace(Stacktrace) ->
 pr_stacktrace(Stacktrace, {Class, Reason}) ->
     lists:flatten(
         pr_stacktrace(Stacktrace) ++ "\n" ++ io_lib:format("~s:~p", [Class, Reason])).
-
-rotate_file(FileName) ->
-    Handlers = lager_config:global_get(handlers),
-    RotateHandlers = lists:filter(
-        fun ({{lager_file_backend, FN}, _, _}) ->
-                FN == FileName orelse 
-                lager_util:expand_path(FN) == lager_util:expand_path(FileName);
-            (_) -> false
-        end,
-        Handlers),
-    rotate_handlers(RotateHandlers).
-
+    
 rotate_sink(Sink) ->
     Handlers = lager_config:global_get(handlers),
-    RotateHandlers = lists:filter(
-        fun({_,_,S}) -> S == Sink; 
-           (_) -> false 
+    RotateHandlers = lists:filtermap(
+        fun({Handler,_,S}) when S == Sink -> {true, {Handler, Sink}};
+           (_)                            -> false 
         end, 
         Handlers),
     rotate_handlers(RotateHandlers).
 
 rotate_all() -> 
-    rotate_handlers(lager_config:global_get(handlers)).
+    rotate_handlers(lists:map(fun({H,_,S}) -> {H, S} end,
+                              lager_config:global_get(handlers))).
 
 
 rotate_handlers(Handlers) ->
-    [ rotate_handler(Handler) || Handler <- Handlers ].
+    [ rotate_handler(Handler, Sink) || {Handler, Sink} <- Handlers ].
 
-rotate_handler({Backend, Handler, Sink}) ->
-    gen_event:call(Sink, Backend, rotate, infinity).
 
+rotate_handler(Handler) ->
+    Handlers = lager_config:global_get(handlers),
+    case lists:keyfind(Handler, 1, Handlers) of
+        {Handler, _, Sink} -> rotate_handler(Handler, Sink);
+        false              -> ok
+    end.
+
+rotate_handler(Handler, Sink) ->
+    gen_event:call(Sink, Handler, rotate, ?ROTATE_TIMEOUT).

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -42,6 +42,7 @@
 
 -export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2,
         code_change/3]).
+-export([rotate_handlers/1, rotate_handler/1]).
 
 -export([config_to_id/1]).
 
@@ -400,6 +401,13 @@ schedule_rotation(_, undefined) ->
 schedule_rotation(Name, Date) ->
     erlang:send_after(lager_util:calculate_next_rotation(Date) * 1000, self(), {rotate, Name}),
     ok.
+
+rotate_handlers(Handlers) ->
+    [ rotate_handler(Handler) || Handler <- Handlers ].
+
+rotate_handler({{lager_file_backend, FileName}, Handler, _Sink}) ->
+    Handler ! {rotate, lager_util:expand_path(FileName)};
+rotate_handler(_) -> ok.
 
 -ifdef(TEST).
 

--- a/test/lager_rotate.erl
+++ b/test/lager_rotate.erl
@@ -45,7 +45,7 @@ rotate_test_() ->
             fun() ->
                 lager:log(error, self(), "Test message 1"),
                 lager:log(sink_event, error, self(), "Sink test message 1", []),
-                lager:rotate_file("test1.log"),
+                lager:rotate_handler({lager_file_backend, "test1.log"}),
                 timer:sleep(1000),
                 true = filelib:is_regular("test1.log.0"),
                 lager:log(error, self(), "Test message 2"),
@@ -118,6 +118,9 @@ rotate_test_() ->
 
                 have_no_log(SinkFile, <<"Sink test message 1">>),
                 have_log(SinkFile, <<"Sink test message 2">>),
+
+                have_log(SinkFileOld, <<"Sink test message 1">>),
+                have_no_log(SinkFileOld, <<"Sink test message 2">>),
 
                 have_log(File1Old, <<"Test message 1">>),
                 have_no_log(File1Old, <<"Test message 2">>),

--- a/test/lager_rotate.erl
+++ b/test/lager_rotate.erl
@@ -1,0 +1,135 @@
+-module(lager_rotate).
+
+-compile(export_all).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+
+rotate_test_() ->
+    {foreach,
+        fun() ->
+                file:write_file("test1.log", ""),
+                file:write_file("test2.log", ""),
+                file:write_file("test3.log", ""),
+                file:delete("test1.log.0"),
+                file:delete("test2.log.0"),
+                file:delete("test3.log.0"),
+                error_logger:tty(false),
+                application:load(lager),
+                application:set_env(lager, handlers, 
+                    [{lager_file_backend, [{file, "test1.log"}, {level, info}]},
+                     {lager_file_backend, [{file, "test2.log"}, {level, info}]}]),
+                application:set_env(lager, extra_sinks,
+                    [{sink_event, 
+                        [{handlers, 
+                            [{lager_file_backend, [{file, "test3.log"}, {level, info}]}]}
+                        ]}]),
+                application:set_env(lager, error_logger_redirect, false),
+                application:set_env(lager, async_threshold, undefined),
+                lager:start()
+        end,
+        fun(_) ->
+                file:delete("test1.log"),
+                file:delete("test2.log"),
+                file:delete("test3.log"),
+                file:delete("test1.log.0"),
+                file:delete("test2.log.0"),
+                file:delete("test3.log.0"),
+                application:stop(lager),
+                application:stop(goldrush),
+                error_logger:tty(true)
+        end,
+        [{"Rotate single file",
+            fun() ->
+                lager:log(error, self(), "Test message 1"),
+                lager:log(sink_event, error, self(), "Sink test message 1", []),
+                lager:rotate_file("test1.log"),
+                timer:sleep(1000),
+                true = filelib:is_regular("test1.log.0"),
+                lager:log(error, self(), "Test message 2"),
+                lager:log(sink_event, error, self(), "Sink test message 2", []),
+                
+                {ok, File1} = file:read_file("test1.log"),
+                {ok, File2} = file:read_file("test2.log"),
+                {ok, SinkFile} = file:read_file("test3.log"),
+                {ok, File1Old} = file:read_file("test1.log.0"),
+
+                have_no_log(File1, <<"Test message 1">>),
+                have_log(File1, <<"Test message 2">>),
+
+                have_log(File2, <<"Test message 1">>),
+                have_log(File2, <<"Test message 2">>),
+
+                have_log(File1Old, <<"Test message 1">>),
+                have_no_log(File1Old, <<"Test message 2">>),
+
+                have_log(SinkFile, <<"Sink test message 1">>),
+                have_log(SinkFile, <<"Sink test message 2">>)
+            end},
+         {"Rotate sink",
+            fun() ->
+                lager:log(error, self(), "Test message 1"),
+                lager:log(sink_event, error, self(), "Sink test message 1", []),
+                lager:rotate_sink(sink_event),
+                timer:sleep(1000),
+                true = filelib:is_regular("test3.log.0"),
+                lager:log(error, self(), "Test message 2"),
+                lager:log(sink_event, error, self(), "Sink test message 2", []),
+                {ok, File1} = file:read_file("test1.log"),
+                {ok, File2} = file:read_file("test2.log"),
+                {ok, SinkFile} = file:read_file("test3.log"),
+                {ok, SinkFileOld} = file:read_file("test3.log.0"),
+
+                have_log(File1, <<"Test message 1">>),
+                have_log(File1, <<"Test message 2">>),
+
+                have_log(File2, <<"Test message 1">>),
+                have_log(File2, <<"Test message 2">>),
+
+                have_log(SinkFileOld, <<"Sink test message 1">>),
+                have_no_log(SinkFileOld, <<"Sink test message 2">>),
+
+                have_no_log(SinkFile, <<"Sink test message 1">>),
+                have_log(SinkFile, <<"Sink test message 2">>)
+            end},
+         {"Rotate all",
+            fun() ->
+                lager:log(error, self(), "Test message 1"),
+                lager:log(sink_event, error, self(), "Sink test message 1", []),
+                lager:rotate_all(),
+                timer:sleep(1000),
+                true = filelib:is_regular("test3.log.0"),
+                lager:log(error, self(), "Test message 2"),
+                lager:log(sink_event, error, self(), "Sink test message 2", []),
+                {ok, File1} = file:read_file("test1.log"),
+                {ok, File2} = file:read_file("test2.log"),
+                {ok, SinkFile} = file:read_file("test3.log"),
+                {ok, File1Old} = file:read_file("test1.log.0"),
+                {ok, File2Old} = file:read_file("test2.log.0"),
+                {ok, SinkFileOld} = file:read_file("test3.log.0"),
+
+                have_no_log(File1, <<"Test message 1">>),
+                have_log(File1, <<"Test message 2">>),
+
+                have_no_log(File2, <<"Test message 1">>),
+                have_log(File2, <<"Test message 2">>),
+
+                have_no_log(SinkFile, <<"Sink test message 1">>),
+                have_log(SinkFile, <<"Sink test message 2">>),
+
+                have_log(File1Old, <<"Test message 1">>),
+                have_no_log(File1Old, <<"Test message 2">>),
+
+                have_log(File2Old, <<"Test message 1">>),
+                have_no_log(File2Old, <<"Test message 2">>)
+
+            end}]}.
+
+have_log(Data, Log) ->
+    {_,_} = binary:match(Data, Log).
+
+have_no_log(Data, Log) ->
+    nomatch = binary:match(Data, Log).
+


### PR DESCRIPTION
Can be used with `logrotate` scripts to have more control over log rotation, while still using lager log rotation features.