### PR TITLE
Bump goldrush to 0.1.8 for not equal filters

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -44,7 +44,7 @@
     nowarn_export_all
 ]}.
 {deps, [
-    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.7"}}}
+    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.8"}}}
 ]}.
 
 {xref_checks, []}.


### PR DESCRIPTION
The upstream goldrush library added support for not equal filters. All lager tests pass.