### PR TITLE
Bump goldrush to 0.1.8

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
     warn_untyped_record
 ]}.
 {deps, [
-    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.7"}}}
+    {goldrush, ".*", {git, "git://github.com/DeadZen/goldrush.git", {tag, "0.1.8"}}}
 ]}.
 
 {xref_checks, []}.


### PR DESCRIPTION
This mirrors a bump on the master (3.x) branch #313 