### PR TITLE
Close file right after rotation

### DIFF
--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -186,7 +186,8 @@ handle_info(_Info, State) ->
 
 %% @private
 terminate(_Reason, State) ->
-    close_file(State),
+    %% leaving this function call unmatched makes dialyzer cranky
+    _ = close_file(State),
     ok.
 
 %% @private


### PR DESCRIPTION
This PR supersedes #312 and includes a trivial fix for an unmatched function return that makes dialyzer cranky.