### PR TITLE
fix function calls not available in R15

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -73,7 +73,10 @@ set_high_water(N) ->
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
     Shaper = #lager_shaper{hwm=HighWaterMark},
-    Raw = application:get_env(lager, error_logger_format_raw, false),
+    Raw = case application:get_env(lager, error_logger_format_raw) of
+        {ok, Value} -> Value;
+        undefined -> false
+    end,
     Sink = configured_sink(),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy, raw=Raw}}.
 
@@ -104,7 +107,10 @@ terminate(_Reason, _State) ->
 
 
 code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
-    Raw = application:get_env(lager, error_logger_format_raw, false),
+    Raw = case application:get_env(lager, error_logger_format_raw, false) of
+        {ok, Value} -> Value;
+        undefined -> false
+    end,
     {ok, #state{
         sink=configured_sink(), 
         shaper=Shaper, 
@@ -112,7 +118,10 @@ code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
         raw=Raw
         }};
 code_change(_OldVsn, {state, Sink, Shaper, GLS}, _Extra) ->
-    Raw = application:get_env(lager, error_logger_format_raw, false),
+    Raw = case application:get_env(lager, error_logger_format_raw) of
+        {ok, Value} -> Value;
+        undefined -> false
+    end,
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GLS, raw=Raw}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -120,7 +129,11 @@ code_change(_OldVsn, State, _Extra) ->
 %% internal functions
 
 configured_sink() ->
-    case proplists:get_value(?ERROR_LOGGER_SINK, application:get_env(lager, extra_sinks, [])) of
+    ExtraSinks = case application:get_env(lager, extra_sinks) of
+        {ok, Value} -> Value;
+        undefined -> []
+    end,
+    case proplists:get_value(?ERROR_LOGGER_SINK, ExtraSinks) of
         undefined -> ?DEFAULT_SINK;
         _ -> ?ERROR_LOGGER_SINK
     end.

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -107,7 +107,7 @@ terminate(_Reason, _State) ->
 
 
 code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
-    Raw = case application:get_env(lager, error_logger_format_raw, false) of
+    Raw = case application:get_env(lager, error_logger_format_raw) of
         {ok, Value} -> Value;
         undefined -> false
     end,


### PR DESCRIPTION
In the rest of lager, application:get_env/3 isn't used. `lager_app` specifically calls
out that the call isn't available in R15. This module, `error_logger_lager_h`, is the
only module that uses it, and this is a relatively simple fix.