### PR TITLE
Address #332: try both id and name

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -295,7 +295,10 @@ format_offender(Off) ->
         MFArgs ->
             %% regular supervisor
             MFA = format_mfa(MFArgs),
-            Name = get_value(name, Off),
+
+            %% In 2014 the error report changed from `name' to
+            %% `id', so try that first.
+            Name = get_value(id, Off, get_value(name, Off)),
             io_lib:format("~p started with ~s at ~w",
                 [Name, MFA, get_value(pid, Off)])
     end.

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -298,7 +298,12 @@ format_offender(Off) ->
 
             %% In 2014 the error report changed from `name' to
             %% `id', so try that first.
-            Name = get_value(id, Off, get_value(name, Off)),
+            Name = case get_value(id, Off) of
+                       undefined ->
+                           get_value(name, Off);
+                       Id ->
+                           Id
+                   end,
             io_lib:format("~p started with ~s at ~w",
                 [Name, MFA, get_value(pid, Off)])
     end.


### PR DESCRIPTION
The `stdlib` module `supervisor` reports the child name as `id` now vs `name` previously