### PR TITLE
Leverage existing lager_app:get_env wrapper for error_logger_lager_h

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -73,7 +73,7 @@ set_high_water(N) ->
 -spec init(any()) -> {ok, #state{}}.
 init([HighWaterMark, GlStrategy]) ->
     Shaper = #lager_shaper{hwm=HighWaterMark},
-    Raw = application:get_env(lager, error_logger_format_raw, false),
+    Raw = lager_app:get_env(lager, error_logger_format_raw, false),
     Sink = configured_sink(),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GlStrategy, raw=Raw}}.
 
@@ -104,7 +104,7 @@ terminate(_Reason, _State) ->
 
 
 code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
-    Raw = application:get_env(lager, error_logger_format_raw, false),
+    Raw = lager_app:get_env(lager, error_logger_format_raw, false),
     {ok, #state{
         sink=configured_sink(), 
         shaper=Shaper, 
@@ -112,7 +112,7 @@ code_change(_OldVsn, {state, Shaper, GLStrategy}, _Extra) ->
         raw=Raw
         }};
 code_change(_OldVsn, {state, Sink, Shaper, GLS}, _Extra) ->
-    Raw = application:get_env(lager, error_logger_format_raw, false),
+    Raw = lager_app:get_env(lager, error_logger_format_raw, false),
     {ok, #state{sink=Sink, shaper=Shaper, groupleader_strategy=GLS, raw=Raw}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -120,7 +120,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% internal functions
 
 configured_sink() ->
-    case proplists:get_value(?ERROR_LOGGER_SINK, application:get_env(lager, extra_sinks, [])) of
+    case proplists:get_value(?ERROR_LOGGER_SINK, lager_app:get_env(lager, extra_sinks, [])) of
         undefined -> ?DEFAULT_SINK;
         _ -> ?ERROR_LOGGER_SINK
     end.

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -30,6 +30,10 @@
          start_handler/3,
          stop/1]).
 
+%% The `application:get_env/3` compatibility wrapper is useful
+%% for other modules
+-export([get_env/3]).
+
 -define(FILENAMES, '__lager_file_backend_filenames').
 -define(THROTTLE, lager_backend_throttle).
 -define(DEFAULT_HANDLER_CONF,

--- a/src/lager_stdlib.erl
+++ b/src/lager_stdlib.erl
@@ -83,12 +83,7 @@ maybe_utc(Time) ->
             Val;
         undefined ->
             %% Backwards compatible:
-            case application:get_env(stdlib, utc_log) of
-                {ok, Val} ->
-                    Val;
-                undefined ->
-                    false
-            end
+            lager_app:get_env(stdlib, utc_log, false)
     end,
     if
         UTC =:= true ->


### PR DESCRIPTION
Thanks to @zzantozz and @tonyrog for prodding us on this. We already had a compatibility function for R15 in `lager_app`; this exposes it and uses it in `error_logger_lager_h`.

Addresses #329 (RIAK-2436) and supersedes #325 (RIAK-1644).