### PR TITLE
Put the warning map value into process dictionary (Fix OTP 18 test failures)

### DIFF
--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1128,8 +1128,9 @@ error_logger_redirect_test_() ->
             },
             {"warning messages with unicode characters in Args are printed",
                 fun(Sink) ->
-                        sync_error_logger:warning_msg("~ts", ["Привет!"]),
                         Map = error_logger:warning_map(),
+                        put(warning_map, Map),
+                        sync_error_logger:warning_msg("~ts", ["Привет!"]),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
                         ?assertEqual(lager_util:level_to_num(Map),Level),
@@ -1140,8 +1141,9 @@ error_logger_redirect_test_() ->
 
             {"warning messages are printed at the correct level",
                 fun(Sink) ->
-                        sync_error_logger:warning_msg("doom, doom has come upon you all"),
                         Map = error_logger:warning_map(),
+                        put(warning_map, Map),
+                        sync_error_logger:warning_msg("doom, doom has come upon you all"),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
                         ?assertEqual(lager_util:level_to_num(Map),Level),
@@ -1151,8 +1153,9 @@ error_logger_redirect_test_() ->
             },
             {"warning reports are printed at the correct level",
                 fun(Sink) ->
-                        sync_error_logger:warning_report([{i, like}, pie]),
                         Map = error_logger:warning_map(),
+                        put(warning_map, Map),
+                        sync_error_logger:warning_report([{i, like}, pie]),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
                         ?assertEqual(lager_util:level_to_num(Map),Level),
@@ -1162,8 +1165,9 @@ error_logger_redirect_test_() ->
             },
             {"single term warning reports are printed at the correct level",
                 fun(Sink) ->
-                        sync_error_logger:warning_report({foolish, bees}),
                         Map = error_logger:warning_map(),
+                        put(warning_map, Map),
+                        sync_error_logger:warning_report({foolish, bees}),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
                         ?assertEqual(lager_util:level_to_num(Map),Level),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1127,50 +1127,66 @@ error_logger_redirect_test_() ->
                 end
             },
             {"warning messages with unicode characters in Args are printed",
+             %% The next 4 tests need to store the current value of
+             %% `error_logger:warning_map/0' into a process dictionary
+             %% key `warning_map' so that the error message level used
+             %% to process the log messages will match what lager
+             %% expects.
+             %%
+             %% The atom returned by `error_logger:warning_map/0'
+             %% changed between OTP 17 and 18 (and later releases)
+             %%
+             %% `warning_map' is consumed in the `test/sync_error_logger.erl'
+             %% module. The default message level used in sync_error_logger
+             %% was fine for OTP releases through 17 and then broke
+             %% when 18 was released. By storing the expected value
+             %% in the process dictionary, sync_error_logger will
+             %% use the correct message level to process the
+             %% messages and these tests will no longer
+             %% break.
                 fun(Sink) ->
-                        Map = error_logger:warning_map(),
-                        put(warning_map, Map),
+                        Lvl = error_logger:warning_map(),
+                        put(warning_map, Lvl),
                         sync_error_logger:warning_msg("~ts", ["Привет!"]),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
-                        ?assertEqual(lager_util:level_to_num(Map),Level),
+                        ?assertEqual(lager_util:level_to_num(Lvl),Level),
                         ?assertEqual(self(),proplists:get_value(pid,Metadata)),
                         ?assertEqual("Привет!", lists:flatten(Msg))
                 end
             },
-
             {"warning messages are printed at the correct level",
                 fun(Sink) ->
-                        Map = error_logger:warning_map(),
-                        put(warning_map, Map),
+                        Lvl = error_logger:warning_map(),
+                        put(warning_map, Lvl),
                         sync_error_logger:warning_msg("doom, doom has come upon you all"),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
-                        ?assertEqual(lager_util:level_to_num(Map),Level),
+                        ?assertEqual(lager_util:level_to_num(Lvl),Level),
                         ?assertEqual(self(),proplists:get_value(pid,Metadata)),
                         ?assertEqual("doom, doom has come upon you all", lists:flatten(Msg))
                 end
             },
             {"warning reports are printed at the correct level",
                 fun(Sink) ->
-                        Map = error_logger:warning_map(),
-                        put(warning_map, Map),
+                        Lvl = error_logger:warning_map(),
+                        put(warning_map, Lvl),
                         sync_error_logger:warning_report([{i, like}, pie]),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
-                        ?assertEqual(lager_util:level_to_num(Map),Level),
+                        ?assertEqual(lager_util:level_to_num(Lvl),Level),
                         ?assertEqual(self(),proplists:get_value(pid,Metadata)),
                         ?assertEqual("i: like, pie", lists:flatten(Msg))
                 end
             },
             {"single term warning reports are printed at the correct level",
                 fun(Sink) ->
-                        Map = error_logger:warning_map(),
-                        put(warning_map, Map),
+                        Lvl = error_logger:warning_map(),
+                        put(warning_map, Lvl),
                         sync_error_logger:warning_report({foolish, bees}),
                         _ = gen_event:which_handlers(error_logger),
                         {Level, _, Msg,Metadata} = pop(Sink),
-                        ?assertEqual(lager_util:level_to_num(Map),Level),
+                        ?assertEqual(lager_util:level_to_num(Lvl),Level),
                         ?assertEqual(self(),proplists:get_value(pid,Metadata)),
                         ?assertEqual("{foolish,bees}", lists:flatten(Msg))
                 end


### PR DESCRIPTION
The sync_error_logger file looks up the message level with which to tag a message from a process dictionary entry named `warning_map'. When it is unset, it uses a default mapping which is fine for OTP 17 and before, but in OTP 18 and 19 the value changed from this default.

Now we put the current error logger warning mapping value into the process dictionary regardless of what OTP release tests are running under so that the messages do not cause failed tests if the default mismatches the OTP release default.

Addresses #275