### PR TITLE
Export configure_sink/2 for runtime sink config

### DIFF
--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -28,6 +28,7 @@
 -export([start/0,
          start/2,
          start_handler/3,
+         configure_sink/2,
          stop/1]).
 
 %% The `application:get_env/3` compatibility wrapper is useful


### PR DESCRIPTION
Address #286 (RIAK-2094). This will enable applications to
dynamically configure log sinks, provided they
have already instrumented the code via parse
transformation to use those sinks.