### PR TITLE
Flappy test clean up for TravisCI

### DIFF
--- a/src/lager.erl
+++ b/src/lager.erl
@@ -615,7 +615,6 @@ filtermap(Fun, List1) ->
     lists:foldr(fun(Elem, Acc) ->
                        case Fun(Elem) of
                            false -> Acc;
-                           true -> [Elem|Acc];
                            {true,Value} -> [Value|Acc]
                        end
                 end, [], List1).

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -609,9 +609,20 @@ pr_stacktrace(Stacktrace, {Class, Reason}) ->
     lists:flatten(
         pr_stacktrace(Stacktrace) ++ "\n" ++ io_lib:format("~s:~p", [Class, Reason])).
     
+
+%% R15 compatibility only
+filtermap(Fun, List1) ->
+    lists:foldr(fun(Elem, Acc) ->
+                       case Fun(Elem) of
+                           false -> Acc;
+                           true -> [Elem|Acc];
+                           {true,Value} -> [Value|Acc]
+                       end
+                end, [], List1).
+
 rotate_sink(Sink) ->
     Handlers = lager_config:global_get(handlers),
-    RotateHandlers = lists:filtermap(
+    RotateHandlers = filtermap(
         fun({Handler,_,S}) when S == Sink -> {true, {Handler, Sink}};
            (_)                            -> false 
         end, 

--- a/test/zzzz_gh280_crash.erl
+++ b/test/zzzz_gh280_crash.erl
@@ -10,6 +10,9 @@
 -include_lib("eunit/include/eunit.hrl").
 
 gh280_crash_test() ->
+    {timeout, 30, fun() -> gh280_impl() end}.
+
+gh280_impl() ->
     application:stop(lager),
     application:stop(goldrush),
 
@@ -25,7 +28,7 @@ gh280_crash_test() ->
             {Handler,Reason};
         X -> 
             X
-    after 5000 ->
+    after 10000 ->
         timeout
     end,
     ?assert(Result),

--- a/test/zzzz_gh280_crash.erl
+++ b/test/zzzz_gh280_crash.erl
@@ -25,7 +25,7 @@ gh280_crash_test() ->
             {Handler,Reason};
         X -> 
             X
-    after 1000 ->
+    after 5000 ->
         timeout
     end,
     ?assert(Result),


### PR DESCRIPTION
* filtermap - if we're going to have R15 as a Travis tested platform, this is required to ensure the implementation of the rotate sink feature does not break. (includes a dialyzer fixup)

* replace timer:sleep with wait_until

* increase timeout on gh280 test - 30 second for eunit, 10 seconds to receive the message