### PR TITLE
Incorporate an optional 'sink killer' for load shedding purposes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -52,3 +52,5 @@
 
 {cover_enabled, true}.
 {edoc_opts, [{stylesheet_file, "./priv/edoc.css"}]}.
+
+{eunit_opts, [verbose]}.

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -188,7 +188,7 @@ configure_sink(Sink, SinkDef) ->
     determine_async_behavior(Sink, proplists:get_value(async_threshold, SinkDef),
                              proplists:get_value(async_threshold_window, SinkDef)
                             ),
-    maybe_install_sink_killer(Sink, proplists:get_value(killer_hwm, SinkDef), 
+    _ = maybe_install_sink_killer(Sink, proplists:get_value(killer_hwm, SinkDef), 
                               proplists:get_value(killer_reinstall_after, SinkDef)),
     start_handlers(Sink,
                    proplists:get_value(handlers, SinkDef, [])),
@@ -226,7 +226,7 @@ boot() ->
                              get_env(lager, async_threshold),
                              get_env(lager, async_threshold_window)),
 
-    maybe_install_sink_killer(?DEFAULT_SINK, get_env(lager, killer_hwm), 
+    _ = maybe_install_sink_killer(?DEFAULT_SINK, get_env(lager, killer_hwm), 
                               get_env(lager, killer_reinstall_after)),
 
     start_handlers(?DEFAULT_SINK,

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -157,7 +157,43 @@ start_error_logger_handler(_, HWM, {ok, WhiteList}) ->
                 X <- gen_event:which_handlers(error_logger) -- [error_logger_lager_h | WhiteList]];
         {error, _} ->
             []
-    end.
+    end,
+
+    case application:get_env(lager, killer_hwm) of
+        undefined ->
+            ok;
+        {ok, undefined} ->
+            undefined;
+        {ok, KillerHWM} when is_integer(KillerHWM), KillerHWM >= 0 ->
+            KillerReinstallAfter =
+            case application:get_env(lager, killer_reinstall_after) of
+                undefined ->
+                    5000;
+                {ok, undefined} ->
+                    5000;
+                {ok, V} when is_integer(V), V >= 0 ->
+                    V;
+                {ok, BadKillerReinstallAfter} ->
+                    error_logger:error_msg("Invalid value for 'cooldown': ~p~n", [BadKillerReinstallAfter]),
+                    throw({error, bad_config})
+            end,
+            _ = supervisor:start_child(lager_handler_watcher_sup,
+                    [lager_event, lager_manager_killer, [KillerHWM, KillerReinstallAfter]]),
+            ok;
+        {ok, BadKillerHWM} ->
+            error_logger:error_msg("Invalid value for 'floodline': ~p~n", [BadKillerHWM]),
+            throw({error, bad_config})
+    end,
+
+    Handlers = case application:get_env(lager, handlers) of
+        undefined ->
+            [{lager_console_backend, info},
+             {lager_file_backend, [{file, "log/error.log"},   {level, error}, {size, 10485760}, {date, "$D0"}, {count, 5}]},
+             {lager_file_backend, [{file, "log/console.log"}, {level, info}, {size, 10485760}, {date, "$D0"}, {count, 5}]}];
+        {ok, Val} ->
+            Val
+    end,
+    Handlers.
 
 %% `determine_async_behavior/3' is called with the results from either
 %% `application:get_env/2' and `proplists:get_value/2'. Since

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -29,7 +29,8 @@
          start/2,
          start_handler/3,
          configure_sink/2,
-         stop/1]).
+         stop/1,
+         boot/0]).
 
 %% The `application:get_env/3` compatibility wrapper is useful
 %% for other modules
@@ -234,7 +235,10 @@ get_env_default({ok, Value}, _Default) ->
 
 start(_StartType, _StartArgs) ->
     {ok, Pid} = lager_sup:start_link(),
+    SavedHandlers = boot(),
+    {ok, Pid, SavedHandlers}.
 
+boot() ->
     %% Handle the default sink.
     determine_async_behavior(?DEFAULT_SINK,
                              application:get_env(lager, async_threshold),
@@ -260,8 +264,7 @@ start(_StartType, _StartArgs) ->
 
     clean_up_config_checks(),
 
-    {ok, Pid, SavedHandlers}.
-
+    SavedHandlers.
 
 stop(Handlers) ->
     lists:foreach(fun(Handler) ->

--- a/src/lager_file_backend.erl
+++ b/src/lager_file_backend.erl
@@ -520,7 +520,12 @@ filesystem_test_() ->
                 application:set_env(lager, handlers, [{lager_test_backend, info}]),
                 application:set_env(lager, error_logger_redirect, false),
                 application:set_env(lager, async_threshold, undefined),
-                lager:start()
+                lager:start(),
+                %% race condition where lager logs its own start up
+                %% makes several tests fail. See test/lager_test_backend
+                %% around line 800 for more information.
+                timer:sleep(5),
+                lager_test_backend:flush()
         end,
         fun(_) ->
                 file:delete("test.log"),
@@ -866,7 +871,9 @@ formatting_test_() ->
                 application:load(lager),
                 application:set_env(lager, handlers, [{lager_test_backend, info}]),
                 application:set_env(lager, error_logger_redirect, false),
-                lager:start()
+                lager:start(),
+                %% same race condition issue
+                timer:sleep(5)
         end,
         fun(_) ->
                 file:delete("test.log"),

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -61,6 +61,14 @@ handle_info({gen_event_EXIT, Module, normal}, #state{module=Module} = State) ->
     {stop, normal, State};
 handle_info({gen_event_EXIT, Module, shutdown}, #state{module=Module} = State) ->
     {stop, normal, State};
+handle_info({gen_event_EXIT, Module, {'EXIT', {kill_me, [KillerHWM, KillerReinstallAfter]}}},
+        #state{module=Module, event=Event} = State) ->
+    % Brutally kill the manager but stay alive to restore settings.
+    Manager = whereis(Event),
+    unlink(Manager),
+    exit(Manager, kill),
+    erlang:send_after(KillerReinstallAfter, self(), reinstall_handler),
+    {noreply, State#state{config=[KillerHWM, KillerReinstallAfter]}};
 handle_info({gen_event_EXIT, Module, Reason}, #state{module=Module,
         config=Config, sink=Sink} = State) ->
     case lager:log(error, self(), "Lager event handler ~p exited with reason ~s",

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -80,6 +80,9 @@ handle_info({gen_event_EXIT, Module, Reason}, #state{module=Module,
         ok
     end,
     {noreply, State};
+handle_info(reinstall_handler, #state{module=Module, config=Config, sink=Sink} = State) ->
+    install_handler(Sink, Module, Config),
+    {noreply, State};
 handle_info(reboot, State) ->
     lager_app:boot(),
     {noreply, State};

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -88,7 +88,7 @@ handle_info(reinstall_handler, #state{module=Module, config=Config, sink=Sink} =
     install_handler(Sink, Module, Config),
     {noreply, State};
 handle_info({reboot, Sink}, State) ->
-    lager_app:boot(Sink),
+    _ = lager_app:boot(Sink),
     {noreply, State};
 handle_info(stop, State) ->
     {stop, normal, State};

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -63,11 +63,11 @@ handle_info({gen_event_EXIT, Module, shutdown}, #state{module=Module} = State) -
     {stop, normal, State};
 handle_info({gen_event_EXIT, Module, {'EXIT', {kill_me, [_KillerHWM, KillerReinstallAfter]}}},
         #state{module=Module, sink=Sink} = State) ->
-    % Brutally kill the manager but stay alive to restore settings.
+    %% Brutally kill the manager but stay alive to restore settings.
     Manager = whereis(Sink),
     unlink(Manager),
     exit(Manager, kill),
-    erlang:send_after(KillerReinstallAfter, self(), reinstall_handler),
+    erlang:send_after(KillerReinstallAfter, self(), reboot),
     {noreply, State};
 handle_info({gen_event_EXIT, Module, Reason}, #state{module=Module,
         config=Config, sink=Sink} = State) ->
@@ -80,8 +80,8 @@ handle_info({gen_event_EXIT, Module, Reason}, #state{module=Module,
         ok
     end,
     {noreply, State};
-handle_info(reinstall_handler, #state{module=Module, config=Config, sink=Sink} = State) ->
-    install_handler(Sink, Module, Config),
+handle_info(reboot, State) ->
+    lager_app:boot(),
     {noreply, State};
 handle_info(stop, State) ->
     {stop, normal, State};

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -61,14 +61,14 @@ handle_info({gen_event_EXIT, Module, normal}, #state{module=Module} = State) ->
     {stop, normal, State};
 handle_info({gen_event_EXIT, Module, shutdown}, #state{module=Module} = State) ->
     {stop, normal, State};
-handle_info({gen_event_EXIT, Module, {'EXIT', {kill_me, [KillerHWM, KillerReinstallAfter]}}},
-        #state{module=Module, event=Event} = State) ->
+handle_info({gen_event_EXIT, Module, {'EXIT', {kill_me, [_KillerHWM, KillerReinstallAfter]}}},
+        #state{module=Module, sink=Sink} = State) ->
     % Brutally kill the manager but stay alive to restore settings.
-    Manager = whereis(Event),
+    Manager = whereis(Sink),
     unlink(Manager),
     exit(Manager, kill),
     erlang:send_after(KillerReinstallAfter, self(), reinstall_handler),
-    {noreply, State#state{config=[KillerHWM, KillerReinstallAfter]}};
+    {noreply, State};
 handle_info({gen_event_EXIT, Module, Reason}, #state{module=Module,
         config=Config, sink=Sink} = State) ->
     case lager:log(error, self(), "Lager event handler ~p exited with reason ~s",

--- a/src/lager_handler_watcher.erl
+++ b/src/lager_handler_watcher.erl
@@ -150,11 +150,10 @@ reinstall_on_initial_failure_test_() ->
                     application:unset_env(lager, crash_log),
                     lager:start(),
                     try
-                      ?assertEqual(1, lager_test_backend:count()),
                       {_Level, _Time, Message, _Metadata} = lager_test_backend:pop(),
                       ?assertMatch("Lager failed to install handler lager_crash_backend into lager_event, retrying later :"++_, lists:flatten(Message)),
-                      ?assertEqual(0, lager_test_backend:count()),
                       timer:sleep(6000),
+                      lager_test_backend:flush(),
                       ?assertEqual(0, lager_test_backend:count()),
                       ?assert(lists:member(lager_crash_backend, gen_event:which_handlers(lager_event)))
                     after
@@ -177,10 +176,10 @@ reinstall_on_runtime_failure_test_() ->
                     application:unset_env(lager, crash_log),
                     lager:start(),
                     try
-                        ?assertEqual(0, lager_test_backend:count()),
                         ?assert(lists:member(lager_crash_backend, gen_event:which_handlers(lager_event))),
                         timer:sleep(6000),
-                        ?assertEqual(2, lager_test_backend:count()),
+                        _ = lager_test_backend:pop(), %% throw away application start up message
+                        _ = lager_test_backend:pop(), %% throw away gen_event crash message
                         {_Severity, _Date, Msg, _Metadata} = lager_test_backend:pop(),
                         ?assertEqual("Lager event handler lager_crash_backend exited with reason crash", lists:flatten(Msg)),
                         {_Severity2, _Date2, Msg2, _Metadata2} = lager_test_backend:pop(),

--- a/src/lager_manager_killer.erl
+++ b/src/lager_manager_killer.erl
@@ -1,0 +1,44 @@
+-module(lager_manager_killer).
+-author("Sungjin Park <jinni.park@gmail.com>").
+-behavior(gen_event).
+
+-export([init/1, handle_event/2, handle_call/2, handle_info/2, terminate/2, code_change/3]).
+
+-include("lager.hrl").
+
+-record(state, {
+  killer_hwm :: non_neg_integer(),
+  killer_reinstall_after :: non_neg_integer()
+}).
+
+init([KillerHWM, KillerReinstallAfter]) ->
+  {ok, #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}}.
+
+handle_call(get_loglevel, State) ->
+  {ok, {mask, ?LOG_NONE}, State};
+handle_call({set_loglevel, _Level}, State) ->
+  {ok, ok, State};
+handle_call(get_settings, State = #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
+  {ok, [KillerHWM, KillerReinstallAfter], State};
+handle_call(_Request, State) ->
+  {ok, ok, State}.
+
+handle_event({log, _Message}, State = #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
+  {message_queue_len, Len} = process_info(self(), message_queue_len),
+  case Len > KillerHWM of
+    true ->
+      exit({kill_me, [KillerHWM, KillerReinstallAfter]});
+    _ ->
+      {ok, State}
+  end;
+handle_event(_Event, State) ->
+  {ok, State}.
+
+handle_info(_Info, State) ->
+  {ok, State}.
+
+terminate(_Reason, _State) ->
+  ok.
+
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.

--- a/src/lager_manager_killer.erl
+++ b/src/lager_manager_killer.erl
@@ -4,12 +4,17 @@
 
 -export([init/1, handle_event/2, handle_call/2, handle_info/2, terminate/2, code_change/3]).
 
+-export([kill_me/0]).
+
 -include("lager.hrl").
 
 -record(state, {
           killer_hwm :: non_neg_integer(),
           killer_reinstall_after :: non_neg_integer()
          }).
+
+kill_me() ->
+    gen_event:call(lager_event, ?MODULE, kill_self).
 
 init([KillerHWM, KillerReinstallAfter]) ->
     {ok, #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}}.
@@ -20,6 +25,8 @@ handle_call({set_loglevel, _Level}, State) ->
     {ok, ok, State};
 handle_call(get_settings, State = #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
     {ok, [KillerHWM, KillerReinstallAfter], State};
+handle_call(kill_self, #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
+    exit({kill_me, [KillerHWM, KillerReinstallAfter]});
 handle_call(_Request, State) ->
     {ok, ok, State}.
 

--- a/src/lager_manager_killer.erl
+++ b/src/lager_manager_killer.erl
@@ -29,7 +29,9 @@ handle_call(kill_self, #state{killer_hwm=KillerHWM, killer_reinstall_after=Kille
     exit({kill_me, [KillerHWM, KillerReinstallAfter]});
 handle_call(_Request, State) ->
     {ok, ok, State}.
-
+%% It's not the best idea in the world to check the queue length for every
+%% log message.  We can make this operation work on a poll timer in the
+%% future.
 handle_event({log, _Message}, State = #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
     {message_queue_len, Len} = process_info(self(), message_queue_len),
     case Len > KillerHWM of

--- a/src/lager_manager_killer.erl
+++ b/src/lager_manager_killer.erl
@@ -7,38 +7,38 @@
 -include("lager.hrl").
 
 -record(state, {
-  killer_hwm :: non_neg_integer(),
-  killer_reinstall_after :: non_neg_integer()
-}).
+          killer_hwm :: non_neg_integer(),
+          killer_reinstall_after :: non_neg_integer()
+         }).
 
 init([KillerHWM, KillerReinstallAfter]) ->
-  {ok, #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}}.
+    {ok, #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}}.
 
 handle_call(get_loglevel, State) ->
-  {ok, {mask, ?LOG_NONE}, State};
+    {ok, {mask, ?LOG_NONE}, State};
 handle_call({set_loglevel, _Level}, State) ->
-  {ok, ok, State};
+    {ok, ok, State};
 handle_call(get_settings, State = #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
-  {ok, [KillerHWM, KillerReinstallAfter], State};
+    {ok, [KillerHWM, KillerReinstallAfter], State};
 handle_call(_Request, State) ->
-  {ok, ok, State}.
+    {ok, ok, State}.
 
 handle_event({log, _Message}, State = #state{killer_hwm=KillerHWM, killer_reinstall_after=KillerReinstallAfter}) ->
-  {message_queue_len, Len} = process_info(self(), message_queue_len),
-  case Len > KillerHWM of
-    true ->
-      exit({kill_me, [KillerHWM, KillerReinstallAfter]});
-    _ ->
-      {ok, State}
-  end;
+    {message_queue_len, Len} = process_info(self(), message_queue_len),
+    case Len > KillerHWM of
+        true ->
+            exit({kill_me, [KillerHWM, KillerReinstallAfter]});
+        _ ->
+            {ok, State}
+    end;
 handle_event(_Event, State) ->
-  {ok, State}.
+    {ok, State}.
 
 handle_info(_Info, State) ->
-  {ok, State}.
+    {ok, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+    ok.
 
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.

--- a/test/lager_manager_killer_test.erl
+++ b/test/lager_manager_killer_test.erl
@@ -1,0 +1,55 @@
+-module(lager_manager_killer_test).
+-author("Sungjin Park <jinni.park@gmail.com>").
+
+-compile([{parse_transform, lager_transform}]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+overload_test() ->
+  application:stop(lager),
+  application:load(lager),
+  Delay = 1000, % sleep 1 sec on every log
+  KillerHWM = 10, % kill the manager if there are more than 10 pending logs
+  KillerReinstallAfter = 1000, % reinstall killer after 1 sec
+  application:set_env(lager, handlers, [{lager_slow_backend, Delay}]),
+  application:set_env(lager, async_threshold, undefined),
+  application:set_env(lager, killer_hwm, KillerHWM),
+  application:set_env(lager, killer_reinstall_after, KillerReinstallAfter),
+  ensure_started(lager),
+  lager_config:set(async, true),
+  Manager = whereis(lager_event),
+  erlang:trace(all, true, [procs]),
+  [lager:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
+  Margin = 100,
+  receive
+    {trace, Manager, exit, killed} ->
+      ?debugFmt("Manager ~p killed", [Manager])
+  after Delay+Margin ->
+    ?assert(false)
+  end,
+  receive
+    {trace, _Sup, spawn, Pid, Fun} ->
+      ?assert(process_info(Pid, registered_name) =:= {registered_name, lager_event}),
+      ?debugFmt("Manager ~p start with ~p", [Pid, Fun]),
+      ?assertNot(lists:member(lager_manager_killer, gen_event:which_handlers(lager_event)))
+  after Margin ->
+      ?assert(false)
+  end,
+  erlang:trace(all, false, [procs]),
+  timer:sleep(KillerReinstallAfter),
+  ?assert(proplists:get_value(lager_manager_killer, gen_event:which_handlers(lager_event))),
+  ?assert(gen_event:call(lager_event, lager_manager_killer, get_settings) =:= [KillerHWM, KillerReinstallAfter]),
+  ?debugFmt("Killer reinstalled with [~p, ~p]", [KillerHWM, KillerReinstallAfter]),
+  application:stop(lager).
+
+ensure_started(App) ->
+  case application:start(App) of
+    ok ->
+      ok;
+    {error, {not_started, Dep}} ->
+      ensure_started(Dep),
+      ensure_started(App)
+  end.
+
+-endif.

--- a/test/lager_manager_killer_test.erl
+++ b/test/lager_manager_killer_test.erl
@@ -12,7 +12,7 @@ overload_test() ->
   Delay = 1000, % sleep 1 sec on every log
   KillerHWM = 10, % kill the manager if there are more than 10 pending logs
   KillerReinstallAfter = 1000, % reinstall killer after 1 sec
-  application:set_env(lager, handlers, [{lager_slow_backend, Delay}]),
+  application:set_env(lager, handlers, [{lager_slow_backend, [{delay, Delay}]}]),
   application:set_env(lager, async_threshold, undefined),
   application:set_env(lager, killer_hwm, KillerHWM),
   application:set_env(lager, killer_reinstall_after, KillerReinstallAfter),

--- a/test/lager_manager_killer_test.erl
+++ b/test/lager_manager_killer_test.erl
@@ -6,38 +6,42 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-overload_test() ->
-    application:stop(lager),
-    application:load(lager),
-    Delay = 1000, % sleep 1 sec on every log
-    KillerHWM = 10, % kill the manager if there are more than 10 pending logs
-    KillerReinstallAfter = 1000, % reinstall killer after 1 sec
-    application:set_env(lager, handlers, [{lager_slow_backend, [{delay, Delay}]}]),
-    application:set_env(lager, async_threshold, undefined),
-    application:set_env(lager, killer_hwm, KillerHWM),
-    application:set_env(lager, killer_reinstall_after, KillerReinstallAfter),
-    ensure_started(lager),
-    lager_config:set(async, true),
-    Manager = whereis(lager_event),
-    erlang:trace(all, true, [procs]),
-    [lager:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
-    Margin = 100,
-    ok = confirm_manager_exit(Manager, Delay+Margin),
-    ok = confirm_sink_reregister(Margin),
-    erlang:trace(all, false, [procs]),
-    wait_until(fun() ->
-                       case proplists:get_value(lager_manager_killer, gen_event:which_handlers(lager_event)) of
-                           [] -> false;
-                           _ -> true
-                       end
-               end, Margin, 15),
-    wait_until(fun() ->
-                       case gen_event:call(lager_event, lager_manager_killer, get_settings) of
-                           [KillerHWM, KillerReinstallAfter] -> true;
-                           _Other -> false
-                       end
-               end, Margin, 15),
-    application:stop(lager).
+overload_test_() ->
+    {timeout, 60,
+     fun() ->
+             application:stop(lager),
+             application:load(lager),
+             Delay = 1000, % sleep 1 sec on every log
+             KillerHWM = 10, % kill the manager if there are more than 10 pending logs
+             KillerReinstallAfter = 1000, % reinstall killer after 1 sec
+             application:set_env(lager, handlers, [{lager_slow_backend, [{delay, Delay}]}]),
+             application:set_env(lager, async_threshold, undefined),
+             application:set_env(lager, error_logger_redirect, true),
+             application:set_env(lager, killer_hwm, KillerHWM),
+             application:set_env(lager, killer_reinstall_after, KillerReinstallAfter),
+             ensure_started(lager),
+             lager_config:set(async, true),
+             Manager = whereis(lager_event),
+             erlang:trace(all, true, [procs]),
+             [lager:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
+             Margin = 100,
+             ok = confirm_manager_exit(Manager, Delay+Margin),
+             ok = confirm_sink_reregister(Margin),
+             erlang:trace(all, false, [procs]),
+             wait_until(fun() ->
+                                case proplists:get_value(lager_manager_killer, gen_event:which_handlers(lager_event)) of
+                                    [] -> false;
+                                    _ -> true
+                                end
+                        end, Margin, 15),
+             wait_until(fun() ->
+                                case gen_event:call(lager_event, lager_manager_killer, get_settings) of
+                                    [KillerHWM, KillerReinstallAfter] -> true;
+                                    _Other -> false
+                                end
+                        end, Margin, 15),
+             application:stop(lager)
+     end}.
 
 ensure_started(App) ->
     case application:start(App) of

--- a/test/lager_manager_killer_test.erl
+++ b/test/lager_manager_killer_test.erl
@@ -6,6 +6,9 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+-define(TEST_SINK_NAME, '__lager_test_sink').              %% <-- used by parse transform
+-define(TEST_SINK_EVENT, '__lager_test_sink_lager_event'). %% <-- used by lager API calls and internals for gen_event
+
 overload_test_() ->
     {timeout, 60,
      fun() ->
@@ -26,7 +29,7 @@ overload_test_() ->
              [lager:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
              Margin = 100,
              ok = confirm_manager_exit(Manager, Delay+Margin),
-             ok = confirm_sink_reregister(Margin),
+             ok = confirm_sink_reregister(lager_event, Margin),
              erlang:trace(all, false, [procs]),
              wait_until(fun() ->
                                 case proplists:get_value(lager_manager_killer, gen_event:which_handlers(lager_event)) of
@@ -36,6 +39,46 @@ overload_test_() ->
                         end, Margin, 15),
              wait_until(fun() ->
                                 case gen_event:call(lager_event, lager_manager_killer, get_settings) of
+                                    [KillerHWM, KillerReinstallAfter] -> true;
+                                    _Other -> false
+                                end
+                        end, Margin, 15),
+             application:stop(lager)
+     end}.
+
+overload_alternate_sink_test_() ->
+    {timeout, 60,
+     fun() ->
+             application:stop(lager),
+             application:load(lager),
+             Delay = 1000, % sleep 1 sec on every log
+             KillerHWM = 10, % kill the manager if there are more than 10 pending logs
+             KillerReinstallAfter = 1000, % reinstall killer after 1 sec
+             application:set_env(lager, handlers, []),
+             application:set_env(lager, extra_sinks, [{?TEST_SINK_EVENT, [
+                                                                          {handlers, [{lager_slow_backend, [{delay, Delay}]}]},
+                                                                          {killer_hwm, KillerHWM},
+                                                                          {killer_reinstall_after, KillerReinstallAfter},
+                                                                          {async_threshold, undefined}
+                                                                         ]}]),
+             application:set_env(lager, error_logger_redirect, true),
+             ensure_started(lager),
+             lager_config:set({?TEST_SINK_EVENT, async}, true),
+             Manager = whereis(?TEST_SINK_EVENT),
+             erlang:trace(all, true, [procs]),
+             [?TEST_SINK_NAME:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
+             Margin = 100,
+             ok = confirm_manager_exit(Manager, Delay+Margin),
+             ok = confirm_sink_reregister(?TEST_SINK_EVENT, Margin),
+             erlang:trace(all, false, [procs]),
+             wait_until(fun() ->
+                                case proplists:get_value(lager_manager_killer, gen_event:which_handlers(?TEST_SINK_EVENT)) of
+                                    [] -> false;
+                                    _ -> true
+                                end
+                        end, Margin, 15),
+             wait_until(fun() ->
+                                case gen_event:call(?TEST_SINK_EVENT, lager_manager_killer, get_settings) of
                                     [KillerHWM, KillerReinstallAfter] -> true;
                                     _Other -> false
                                 end
@@ -63,10 +106,10 @@ confirm_manager_exit(Manager, Delay) ->
             ?assert(false)
     end.
 
-confirm_sink_reregister(Delay) ->
+confirm_sink_reregister(Sink, Delay) ->
     receive
-        {trace, _Pid, register, lager_event} ->
-            ?assertNot(lists:member(lager_manager_killer, gen_event:which_handlers(lager_event)))
+        {trace, _Pid, register, Sink} ->
+            ?assertNot(lists:member(lager_manager_killer, gen_event:which_handlers(Sink)))
     after Delay ->
             ?assert(false)
     end.

--- a/test/lager_manager_killer_test.erl
+++ b/test/lager_manager_killer_test.erl
@@ -7,49 +7,72 @@
 -include_lib("eunit/include/eunit.hrl").
 
 overload_test() ->
-  application:stop(lager),
-  application:load(lager),
-  Delay = 1000, % sleep 1 sec on every log
-  KillerHWM = 10, % kill the manager if there are more than 10 pending logs
-  KillerReinstallAfter = 1000, % reinstall killer after 1 sec
-  application:set_env(lager, handlers, [{lager_slow_backend, [{delay, Delay}]}]),
-  application:set_env(lager, async_threshold, undefined),
-  application:set_env(lager, killer_hwm, KillerHWM),
-  application:set_env(lager, killer_reinstall_after, KillerReinstallAfter),
-  ensure_started(lager),
-  lager_config:set(async, true),
-  Manager = whereis(lager_event),
-  erlang:trace(all, true, [procs]),
-  [lager:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
-  Margin = 100,
-  receive
-    {trace, Manager, exit, killed} ->
-      ?debugFmt("Manager ~p killed", [Manager])
-  after Delay+Margin ->
-    ?assert(false)
-  end,
-  receive
-    {trace, _Sup, spawn, Pid, Fun} ->
-      ?assert(process_info(Pid, registered_name) =:= {registered_name, lager_event}),
-      ?debugFmt("Manager ~p start with ~p", [Pid, Fun]),
-      ?assertNot(lists:member(lager_manager_killer, gen_event:which_handlers(lager_event)))
-  after Margin ->
-      ?assert(false)
-  end,
-  erlang:trace(all, false, [procs]),
-  timer:sleep(KillerReinstallAfter),
-  ?assert(proplists:get_value(lager_manager_killer, gen_event:which_handlers(lager_event))),
-  ?assert(gen_event:call(lager_event, lager_manager_killer, get_settings) =:= [KillerHWM, KillerReinstallAfter]),
-  ?debugFmt("Killer reinstalled with [~p, ~p]", [KillerHWM, KillerReinstallAfter]),
-  application:stop(lager).
+    application:stop(lager),
+    application:load(lager),
+    Delay = 1000, % sleep 1 sec on every log
+    KillerHWM = 10, % kill the manager if there are more than 10 pending logs
+    KillerReinstallAfter = 1000, % reinstall killer after 1 sec
+    application:set_env(lager, handlers, [{lager_slow_backend, [{delay, Delay}]}]),
+    application:set_env(lager, async_threshold, undefined),
+    application:set_env(lager, killer_hwm, KillerHWM),
+    application:set_env(lager, killer_reinstall_after, KillerReinstallAfter),
+    ensure_started(lager),
+    lager_config:set(async, true),
+    Manager = whereis(lager_event),
+    erlang:trace(all, true, [procs]),
+    [lager:info("~p'th message", [N]) || N <- lists:seq(1,KillerHWM+2)],
+    Margin = 100,
+    ok = confirm_manager_exit(Manager, Delay+Margin),
+    ok = confirm_sink_reregister(Margin),
+    erlang:trace(all, false, [procs]),
+    wait_until(fun() ->
+                       case proplists:get_value(lager_manager_killer, gen_event:which_handlers(lager_event)) of
+                           [] -> false;
+                           _ -> true
+                       end
+               end, Margin, 15),
+    wait_until(fun() ->
+                       case gen_event:call(lager_event, lager_manager_killer, get_settings) of
+                           [KillerHWM, KillerReinstallAfter] -> true;
+                           _Other -> false
+                       end
+               end, Margin, 15),
+    application:stop(lager).
 
 ensure_started(App) ->
-  case application:start(App) of
-    ok ->
-      ok;
-    {error, {not_started, Dep}} ->
-      ensure_started(Dep),
-      ensure_started(App)
-  end.
+    case application:start(App) of
+        ok ->
+            ok;
+        {error, {not_started, Dep}} ->
+            ensure_started(Dep),
+            ensure_started(App)
+    end.
+
+confirm_manager_exit(Manager, Delay) ->
+    receive
+        {trace, Manager, exit, killed} ->
+            ?debugFmt("Manager ~p killed", [Manager]);
+        Other ->
+            ?debugFmt("OTHER MSG: ~p", [Other]),
+            confirm_manager_exit(Manager, Delay)
+    after Delay ->
+            ?assert(false)
+    end.
+
+confirm_sink_reregister(Delay) ->
+    receive
+        {trace, _Pid, register, lager_event} ->
+            ?assertNot(lists:member(lager_manager_killer, gen_event:which_handlers(lager_event)))
+    after Delay ->
+            ?assert(false)
+    end.
+
+wait_until(_Fun, _Delay, 0) ->
+    {error, too_many_retries};
+wait_until(Fun, Delay, Retries) ->
+    case Fun() of
+        true -> ok;
+        false -> timer:sleep(Delay), wait_until(Fun, Delay, Retries-1)
+    end.
 
 -endif.

--- a/test/lager_slow_backend.erl
+++ b/test/lager_slow_backend.erl
@@ -10,7 +10,7 @@
   delay :: non_neg_integer()
 }).
 
-init(Delay) ->
+init([{delay, Delay}]) ->
   {ok, #state{delay=Delay}}.
 
 handle_call(get_loglevel, State) ->

--- a/test/lager_slow_backend.erl
+++ b/test/lager_slow_backend.erl
@@ -1,0 +1,34 @@
+-module(lager_slow_backend).
+-author("Sungjin Park <jinni.park@gmail.com>").
+-behavior(gen_event).
+
+-export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2, code_change/3]).
+
+-include("lager.hrl").
+
+-record(state, {
+  delay :: non_neg_integer()
+}).
+
+init(Delay) ->
+  {ok, #state{delay=Delay}}.
+
+handle_call(get_loglevel, State) ->
+  {ok, lager_util:config_to_mask(debug), State};
+handle_call(_Request, State) ->
+  {ok, ok, State}.
+
+handle_event({log, _Message}, State) ->
+  timer:sleep(State#state.delay),
+  {ok, State};
+handle_event(_Event, State) ->
+  {ok, State}.
+
+handle_info(_Info, State) ->
+  {ok, State}.
+
+terminate(_Reason, _State) ->
+  ok.
+
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -1570,7 +1570,8 @@ async_threshold_test_() ->
                         ?assertEqual(true, lager_config:get(async)),
 
                         %% put a ton of things in the queue
-                        Workers = [spawn_monitor(fun() -> [lager:info("hello world") || _ <- lists:seq(1, 1000)] end) || _ <- lists:seq(1, 15)],
+                        Workers = [spawn_monitor(fun() -> [lager:info("hello world") || _ <- lists:seq(1, 100)] end)
+                                   || _ <- lists:seq(1, 10)],
 
                         %% serialize on mailbox
                         _ = gen_event:which_handlers(lager_event),
@@ -1588,7 +1589,9 @@ async_threshold_test_() ->
                         %% point in the past
                         ?assertMatch([{sync_toggled, N}] when N > 0,
                                                               ets:lookup(async_threshold_test, sync_toggled)),
-                        %% wait for all the workers to return, meaning that all the messages have been logged (since we're definitely in sync mode at the end of the run)
+                        %% wait for all the workers to return, meaning that all
+                        %% the messages have been logged (since we're
+                        %% definitely in sync mode at the end of the run)
                         collect_workers(Workers),
                         %% serialize on the mailbox again
                         _ = gen_event:which_handlers(lager_event),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -515,6 +515,8 @@ lager_test_() ->
                         application:stop(lager),
                         application:set_env(lager, traces, [{lager_test_backend, [{foo, bar}], debug}]),
                         lager:start(),
+                        timer:sleep(5),
+                        flush(),
                         lager:debug([{foo, bar}], "hello world"),
                         ?assertEqual(1, count()),
                         application:unset_env(lager, traces),

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -796,6 +796,18 @@ setup() ->
     application:set_env(lager, error_logger_redirect, false),
     application:unset_env(lager, traces),
     lager:start(),
+    %% There is a race condition between the application start up, lager logging its own
+    %% start up condition and several tests that count messages or parse the output of
+    %% tests.  When the lager start up message wins the race, it causes these tests
+    %% which parse output or count message arrivals to fail.
+    %%
+    %% We introduce a sleep here to allow `flush' to arrive *after* the start up
+    %% message has been received and processed.
+    %%
+    %% This race condition was first exposed during the work on
+    %% 4b5260c4524688b545cc12da6baa2dfa4f2afec9 which introduced the lager
+    %% manager killer PR.
+    timer:sleep(5),
     gen_event:call(lager_event, ?MODULE, flush).
 
 cleanup(_) ->

--- a/test/lager_test_backend.erl
+++ b/test/lager_test_backend.erl
@@ -539,6 +539,7 @@ lager_test_() ->
                 end
             },
             {"stopped trace stops and removes its event handler - default sink (gh#267)",
+             {timeout, 10,
                 fun() ->
                         Sink = ?DEFAULT_SINK,
                         StartHandlers = gen_event:which_handlers(Sink),
@@ -562,14 +563,14 @@ lager_test_() ->
 
                         ?assertEqual(length(StartGlobal)+1, length(lager_config:global_get(handlers))),
                         ok = lager:stop_trace(TestTrace2),
-                        EndHandlers = gen_event:which_handlers(?DEFAULT_SINK),
+                        EndHandlers = gen_event:which_handlers(Sink),
                         EndGlobal = lager_config:global_get(handlers),
                         {_, T3} = lager_config:get({Sink, loglevel}),
                         ?assertEqual([], T3),
                         ?assertEqual(StartHandlers, EndHandlers),
                         ?assertEqual(StartGlobal, EndGlobal),
                         ok
-                end
+                end}
             },
             {"record printing works",
                 fun() ->


### PR DESCRIPTION
Heavily based on work by @jinnipark and @blt, this pull request implements an optional "killer" manager which brutally kills itself as a means of load shedding if a high water mark is reached in the gen_event manager's process mailbox.

Incorporates and supersedes #328. Addresses #324 