### PR TITLE
Cleanup for test, whitespace

### DIFF
--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -23,6 +23,7 @@
 -behaviour(application).
 -include("lager.hrl").
 -ifdef(TEST).
+-compile([export_all]).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 -export([start/0,

--- a/src/lager_app.erl
+++ b/src/lager_app.erl
@@ -237,9 +237,9 @@ boot() ->
     lager:update_loglevel_config(?DEFAULT_SINK),
 
     SavedHandlers = start_error_logger_handler(
-                                    get_env(lager, error_logger_redirect, true),
+                      get_env(lager, error_logger_redirect, true),
                       interpret_hwm(get_env(lager, error_logger_hwm, 0)),
-                                    get_env(lager, error_logger_whitelist, [])
+                      get_env(lager, error_logger_whitelist, [])
                      ),
 
     SavedHandlers.


### PR DESCRIPTION
* Undo unnecessary whitespace
* Make lager_handler_watcher test more resilient by scanning for
  messages of interest rather than assuming we know exactly what
  messages will arrive at the test backend
* `export_all` to allow R15 to run the `lager_app_tests` tests