### PR TITLE
Support typed records newly exposed in OTP 19

### DIFF
--- a/src/lager_transform.erl
+++ b/src/lager_transform.erl
@@ -57,15 +57,18 @@ walk_ast(Acc, [{function, Line, Name, Arity, Clauses}|T]) ->
     walk_ast([{function, Line, Name, Arity,
                 walk_clauses([], Clauses)}|Acc], T);
 walk_ast(Acc, [{attribute, _, record, {Name, Fields}}=H|T]) ->
-    FieldNames = lists:map(fun({record_field, _, {atom, _, FieldName}}) ->
-                FieldName;
-            ({record_field, _, {atom, _, FieldName}, _Default}) ->
-                FieldName
-        end, Fields),
+    FieldNames = lists:map(fun record_field_name/1, Fields),
     stash_record({Name, FieldNames}),
     walk_ast([H|Acc], T);
 walk_ast(Acc, [H|T]) ->
     walk_ast([H|Acc], T).
+
+record_field_name({record_field, _, {atom, _, FieldName}}) ->
+    FieldName;
+record_field_name({record_field, _, {atom, _, FieldName}, _Default}) ->
+    FieldName;
+record_field_name({typed_record_field, Field, _Type}) ->
+    record_field_name(Field).
 
 walk_clauses(Acc, []) ->
     lists:reverse(Acc);


### PR DESCRIPTION
NOTE: Cherry picked from @weisslj's PR #321 for the 2.x series.

Otherwise `lager_transform` fails after https://github.com/erlang/otp/commit/de9012628a6b0e97d2f1325bf2f72817f69f84ee

The error message is:

    test/pr_nested_record_test.erl: error in parse transform 'lager_transform': {function_clause,
                                                 [{lager_transform,
                                                   '-walk_ast/2-fun-0-',
                                                   [{typed_record_field,
                                                     {record_field,5,
                                                      {atom,5,field1}},
                                                     {type,5,term,[]}}],
                                                   [{file,
                                                     "src/lager_transform.erl"},
                                                    {line,62}]},