### PR TITLE
mark for no crash log

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ You can also disable reformatting for OTP and Cowboy messages by setting variabl
 The `error_logger` handler will also log more complete error messages (protected
 with use of `trunc_io`) to a "crash log" which can be referred to for further
 information. The location of the crash log can be specified by the crash_log
-application variable. If set to `undefined` it is not written at all.
+application variable. If set to `false` it is not written at all.
 
 Messages in the crash log are subject to a maximum message size which can be
 specified via the `crash_log_msg_size` application variable.

--- a/src/lager.app.src
+++ b/src/lager.app.src
@@ -30,7 +30,7 @@
 
             ]},
 
-            %% Whether to write a crash log, and where. Undefined means no crash logger.
+            %% Whether to write a crash log, and where. False means no crash logger.
             {crash_log, "log/crash.log"},
             %% Maximum size in bytes of events in the crash log - defaults to 65536
             {crash_log_msg_size, 65536},


### PR DESCRIPTION
Hi:
The `crash_log` application var should be `false`.
Long long ago, it's `undefined`. But, if I set it `undefined` now, the whole node will be crash.
```
16:53:51.007 [error] gen_server lager_crash_log terminated with reason: bad argument in call to erlang:'++'(undefined, ".3") in lager_util:rotate_logfile/2 line 220
16:53:51.007 [error] CRASH REPORT Process lager_crash_log with 0 neighbours exited with reason: bad argument in call to erlang:'++'(undefined, ".3") in lager_util:rotate_logfile/2 line 220
16:53:51.007 [error] Supervisor lager_sup had child lager_crash_log started with lager_crash_log:start_link(undefined, 65536, 10485760, [{hour,0}], 5) at <0.1321.0> exit with reason bad argument in call to erlang:'++'(undefined, ".3") in lager_util:rotate_logfile/2 line 220 in context child_terminated
16:53:51.007 [debug] Supervisor lager_sup started lager_crash_log:start_link(undefined, 65536, 10485760, [{hour,0}], 5) at pid <0.1521.0>
```
