### PR TITLE
Fixed legacy support for {crash_log, undefined}

### DIFF
--- a/src/lager_sup.erl
+++ b/src/lager_sup.erl
@@ -35,8 +35,8 @@ init([]) ->
     %% set up the config, is safe even during relups
     lager_config:new(),
     %% TODO:
-    %% Always start lager_event as the default and make sure that 
-    %% other gen_event stuff can start up as needed 
+    %% Always start lager_event as the default and make sure that
+    %% other gen_event stuff can start up as needed
     %%
     %% Maybe a new API to handle the sink and its policy?
     Children = [
@@ -69,6 +69,8 @@ determine_rotation_date({ok, Val3}) ->
 determine_rotation_date(_) ->
     undefined.
 
+decide_crash_log(undefined) ->
+    [];
 decide_crash_log(false) ->
     [];
 decide_crash_log(File) ->


### PR DESCRIPTION
Applications that explicitly configure lager's `crash_log` with the
value `undefined` will get a really terrible crash message for all
versions since 81222ca4869402b4b790bce3f2df40f9b2d213a0

Diff here: https://github.com/basho/lager/commit/81222ca4869402b4b790bce3f2df40f9b2d213a0#diff-25e915f0df09d04052d2a6e85b8824f2

That message looks like this:

```
** Generic server lager_crash_log terminating
** Last message in was rotate
** When Server state == {state,undefined,
                              {file_descriptor,prim_file,{#Port<0.1340>,15}},
                              281571,65536,10485760,
                              [{hour,0}],
                              5,false}
** Reason for termination ==
** {badarg,[{erlang,'++',[undefined,".3"],[]},
           {lager_util,rotate_logfile,2,
                       [{file,"_build/default/lib/lager/src/lager_util.erl"},
                        {line,220}]},
           {lager_crash_log,handle_info,2,
                            [{file,"_build/default/lib/lager/src/lager_crash_log.erl"},
                             {line,99}]},
           {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,601}]},
           {gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,667}]},
           {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
```

This fix will allow people who use this legacy configuration to not
experience production crashes at midnight after the deploy, when
crash_log tries to rotate for the very first time, resulting in trying
to append `.Int` to `undefined`